### PR TITLE
Configurable random generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- The ability to configure the random generator for the gem via `KSUID.configure`. This allows you to set up random generation to the specifications you need, whether that is for speed or for security.
+
 ## [0.1.0] - 2017-11-05
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gemspec
 
 group :development do
+  gem 'benchmark-ips'
   gem 'guard-bundler'
   gem 'guard-inch'
   gem 'guard-rspec'

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ If you need to generate a KSUID for a specific timestamp, use:
 ksuid = KSUID.new(time: time)  # where time is a Time-like object
 ```
 
+If you need to use a faster or more secure way of generating the random payloads (or if you want the payload to be non-random data), you can configure the gem for those use cases:
+
+```ruby
+KSUID.configure do |config|
+  config.random_generator = -> { Random.new.bytes(16) }
+end
+```
+
 ## Contributing
 
 So you’re interested in contributing to KSUID? Check out our [contributing guidelines](CONTRIBUTING.md) for more information on how to do that.

--- a/benchmark/random_generators.rb
+++ b/benchmark/random_generators.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'benchmark/ips'
+require 'json'
+require 'ksuid'
+
+RESULTS_FILE = '.random_generator.json'
+NON_RANDOM_DATA = "\x00" * 16
+
+3.times do
+  if File.exist?(RESULTS_FILE)
+    results = File.readlines(RESULTS_FILE).map { |line| JSON.parse(line)['item'] }
+
+    if !results.include?('random')
+      generator = Random.new
+      KSUID.configure { |config| config.random_generator = -> { generator.bytes(16) } }
+    else
+      KSUID.configure { |config| config.random_generator = -> { NON_RANDOM_DATA } }
+    end
+  end
+
+  Benchmark.ips do |x|
+    x.report('securerandom') { KSUID.new }
+    x.report('random') { KSUID.new }
+    x.report('non-random') { KSUID.new }
+
+    x.compare!
+    x.hold!(RESULTS_FILE)
+  end
+end

--- a/config.reek
+++ b/config.reek
@@ -1,4 +1,8 @@
 ---
+ManualDispatch:
+  exclude:
+    - "KSUID::Configuration#assert_generator_is_callable"
+
 UncommunicativeModuleName:
   exclude:
     - "KSUID::Base62"

--- a/lib/ksuid.rb
+++ b/lib/ksuid.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative 'ksuid/configuration'
 require_relative 'ksuid/type'
 require_relative 'ksuid/version'
 
@@ -73,6 +74,35 @@ module KSUID
   #
   # @return [String]
   MAX_STRING_ENCODED = 'aWgEPTl1tmebfsQzFP4bxwgy80V'
+
+  # The configuration for creating new KSUIDs
+  #
+  # @api private
+  #
+  # @return [KSUID::Configuration] the gem's configuration
+  def self.config
+    @config ||= KSUID::Configuration.new
+  end
+
+  # Configures the KSUID gem by passing a block
+  #
+  # @api public
+  #
+  # @example Override the random generator with a null data generator
+  #   KSUID.configure do |config|
+  #     config.random_generator = -> { "\x00" * KSUID::BYTES[:payload] }
+  #   end
+  #
+  # @example Override the random generator with the faster, but less secure, Random
+  #   KSUID.configure do |config|
+  #     config.random_generator = -> { Random.new.bytes(KSUID::BYTES[:payload]) }
+  #   end
+  #
+  # @return [KSUID::Configuration] the gem's configuration
+  def self.configure
+    yield config if block_given?
+    config
+  end
 
   # Converts a base 62-encoded string into a KSUID
   #

--- a/lib/ksuid/configuration.rb
+++ b/lib/ksuid/configuration.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module KSUID
+  # Encapsulates the configuration for the KSUID gem as a whole.
+  #
+  # You can override the generation of the random payload data by setting the
+  # {#random_generator} value to a valid random payload generator. This should
+  # be done via the module-level {KSUID.configure} method.
+  #
+  # The gem-level configuration lives at the module-level {KSUID.config}.
+  #
+  # @api semipublic
+  class Configuration
+    # Raised when the gem is misconfigured.
+    ConfigurationError = Class.new(StandardError)
+
+    # Instantiates a new KSUID configuration
+    #
+    # @api private
+    #
+    # @return [KSUID::Configuration] the new configuration
+    def initialize
+      self.random_generator = default_generator
+    end
+
+    # The method for generating random payloads in the gem
+    #
+    # @api private
+    #
+    # @return [#call] a callable that returns 16 bytes
+    attr_reader :random_generator
+
+    # Override the method for generating random payloads in the gem
+    #
+    # @api semipublic
+    #
+    # @example Override the random generator with a null data generator
+    #   KSUID.configure do |config|
+    #     config.random_generator = -> { "\x00" * KSUID::BYTES[:payload] }
+    #   end
+    #
+    # @example Override the random generator with the faster, but less secure, Random
+    #   KSUID.configure do |config|
+    #     config.random_generator = -> { Random.new.bytes(KSUID::BYTES[:payload]) }
+    #   end
+    #
+    # @param generator [#call] a callable that returns 16 bytes
+    # @return [#call] a callable that returns 16 bytes
+    def random_generator=(generator)
+      assert_generator_is_callable(generator)
+      assert_payload_size(generator)
+
+      @random_generator = generator
+    end
+
+    private
+
+    # Raises an error if the assigned generator is not callable
+    #
+    # @api private
+    #
+    # @raise [ConfigurationError] if the generator is not callable
+    # @return [nil]
+    def assert_generator_is_callable(generator)
+      return if generator.respond_to?(:call)
+
+      raise ConfigurationError, "Random generator #{generator} is not callable"
+    end
+
+    # Raises an error if the assigned generator generates the wrong size
+    #
+    # @api private
+    #
+    # @raise [ConfigurationError] if the generator generates the wrong size payload
+    # @return [nil]
+    def assert_payload_size(generator)
+      return if (length = generator.call.length) == (expected_length = BYTES[:payload])
+
+      raise ConfigurationError, 'Random generator generates the wrong number of bytes ' \
+        "(#{length} generated, #{expected_length} expected)"
+    end
+
+    # The default generator for generating random payloads
+    #
+    # @api private
+    #
+    # @return [Proc]
+    def default_generator
+      -> { SecureRandom.random_bytes(BYTES[:payload]) }
+    end
+  end
+end

--- a/lib/ksuid/type.rb
+++ b/lib/ksuid/type.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'securerandom'
 require_relative 'base62'
 require_relative 'utils'
 
@@ -35,7 +34,7 @@ module KSUID
     # @param time [Time] the timestamp to use for the KSUID
     # @return [KSUID::Type] the generated KSUID
     def initialize(payload: nil, time: Time.now)
-      payload ||= SecureRandom.random_bytes(BYTES[:payload])
+      payload ||= KSUID.config.random_generator.call
       byte_encoding = Utils.int_to_bytes(time.to_i - EPOCH_TIME)
 
       @uid = byte_encoding.bytes + payload.bytes

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe KSUID::Configuration do
+  describe '#random_generator' do
+    it 'defaults to using secure random' do
+      config = described_class.new
+
+      random = config.random_generator.call
+
+      expect(random.size).to eq(16)
+    end
+
+    it 'can be overridden with a proper random generator' do
+      config = described_class.new
+      config.random_generator = -> { Random.new.bytes(16) }
+
+      random = config.random_generator.call
+
+      expect(random.size).to eq(16)
+    end
+
+    it 'cannot be overridden by a non-callable' do
+      config = described_class.new
+
+      expect { config.random_generator = 'Hello' }.to raise_error(
+        KSUID::Configuration::ConfigurationError
+      )
+    end
+
+    it 'cannot be overriden by a generator of the wrong length' do
+      config = described_class.new
+      short_generator = -> { Random.new.bytes(5) }
+
+      expect { config.random_generator = short_generator }.to raise_error(
+        KSUID::Configuration::ConfigurationError
+      )
+    end
+  end
+end

--- a/spec/ksuid_spec.rb
+++ b/spec/ksuid_spec.rb
@@ -4,4 +4,12 @@ RSpec.describe KSUID do
   it 'has a version number' do
     expect(KSUID::VERSION).not_to be nil
   end
+
+  it 'is configurable' do
+    generator = -> { "\x00" * KSUID::BYTES[:payload] }
+
+    KSUID.configure { |config| config.random_generator = generator }
+
+    expect(KSUID.config.random_generator).to eq(generator)
+  end
 end


### PR DESCRIPTION
Add the ability to configure the random generator, for different use cases. Also, include some benchmarks to compare a few different strategies. Interestingly, the benchmarks show that SecureRandom, Random, and a string literal all perform roughly the same!

Closes #1