### PR TITLE
Clean up some testing deficiencies uncovered from mutation testing

### DIFF
--- a/.mutant.yml
+++ b/.mutant.yml
@@ -1,0 +1,6 @@
+ignore_subjects:
+  - "KSUID::ActiveRecord.[]"
+  - "KSUID::ActiveRecord.define_attribute"
+  - "KSUID::ActiveRecord.define_created_at"
+  - "KSUID::Backports*"
+  - "KSUID::Configuration.default_generator" # The mutatations here hide some context, which isn't helpful

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,3 +37,7 @@ Metrics/MethodLength:
 Naming/FileName:
   Exclude:
     - "Appraisals"
+
+# We support older Rubies than 2.4. We can re-enable when we drop support for Ruby 2.3.
+Style/UnpackFirst:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,8 @@ group :development do
   gem 'guard-rubocop'
   gem 'guard-yard'
   gem 'inch'
-  gem 'mutant-rspec'
+  gem 'mutant', github: 'mbj/mutant', ref: '3eb55274aa151626eff53df14d1199f2d92b1952'
+  gem 'mutant-rspec', github: 'mbj/mutant', ref: '3eb55274aa151626eff53df14d1199f2d92b1952'
   gem 'rubocop', '0.51.0'
   gem 'yard', '~> 0.9'
   gem 'yard-doctest'
@@ -34,4 +35,5 @@ end
 group :test do
   gem 'appraisal'
   gem 'rspec', '~> 3.6'
+  gem 'timecop'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -48,16 +48,25 @@ with_optional_dependency do
   default << 'inch'
 end
 
-task :mutant do
+task :mutant, %i[matcher] do |_task, args|
+  args.with_defaults(matcher: 'KSUID*')
+
   command = [
+    'MUTANT=1',
     'bundle exec mutant',
     '--include lib',
     '--require ksuid',
-    '--use rspec',
-    'KSUID*'
-  ].join(' ')
+    '--use rspec'
+  ]
 
-  system command
+  config = YAML.safe_load(File.read('.mutant.yml'))
+  config['ignore_subjects'].each do |subject|
+    command << "--ignore-subject #{subject}"
+  end
+
+  command << args[:matcher]
+
+  system command.join(' ')
 end
 
 with_optional_dependency do

--- a/config.reek
+++ b/config.reek
@@ -19,6 +19,7 @@ UncommunicativeModuleName:
 UncommunicativeMethodName:
   exclude:
     - "KSUID#self.from_base62"
+    - "KSUID::Backports#unpack1"
 
 UtilityFunction:
   exclude:

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -14,7 +14,8 @@ group :development do
   gem "guard-rubocop"
   gem "guard-yard"
   gem "inch"
-  gem "mutant-rspec"
+  gem "mutant", github: "mbj/mutant", ref: "3eb55274aa151626eff53df14d1199f2d92b1952"
+  gem "mutant-rspec", github: "mbj/mutant", ref: "3eb55274aa151626eff53df14d1199f2d92b1952"
   gem "rubocop", "0.51.0"
   gem "yard", "~> 0.9"
   gem "yard-doctest"
@@ -34,6 +35,7 @@ end
 group :test do
   gem "appraisal"
   gem "rspec", "~> 3.6"
+  gem "timecop"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -14,7 +14,8 @@ group :development do
   gem "guard-rubocop"
   gem "guard-yard"
   gem "inch"
-  gem "mutant-rspec"
+  gem "mutant", github: "mbj/mutant", ref: "3eb55274aa151626eff53df14d1199f2d92b1952"
+  gem "mutant-rspec", github: "mbj/mutant", ref: "3eb55274aa151626eff53df14d1199f2d92b1952"
   gem "rubocop", "0.51.0"
   gem "yard", "~> 0.9"
   gem "yard-doctest"
@@ -34,6 +35,7 @@ end
 group :test do
   gem "appraisal"
   gem "rspec", "~> 3.6"
+  gem "timecop"
 end
 
 gemspec path: "../"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -14,7 +14,8 @@ group :development do
   gem "guard-rubocop"
   gem "guard-yard"
   gem "inch"
-  gem "mutant-rspec"
+  gem "mutant", github: "mbj/mutant", ref: "3eb55274aa151626eff53df14d1199f2d92b1952"
+  gem "mutant-rspec", github: "mbj/mutant", ref: "3eb55274aa151626eff53df14d1199f2d92b1952"
   gem "rubocop", "0.51.0"
   gem "yard", "~> 0.9"
   gem "yard-doctest"
@@ -34,6 +35,7 @@ end
 group :test do
   gem "appraisal"
   gem "rspec", "~> 3.6"
+  gem "timecop"
 end
 
 gemspec path: "../"

--- a/lib/ksuid.rb
+++ b/lib/ksuid.rb
@@ -89,11 +89,11 @@ module KSUID
     return unless ksuid
 
     case ksuid
-    when KSUID::Type then ksuid
-    when Array then KSUID.from_bytes(ksuid)
+    when Type then ksuid
+    when Array then from_bytes(ksuid)
     when String then cast_string(ksuid)
     else
-      raise ArgumentError, "Cannot convert #{ksuid.inspect} to KSUID"
+      raise ArgumentError, "Cannot convert #{ksuid} to KSUID"
     end
   end
 
@@ -103,7 +103,7 @@ module KSUID
   #
   # @return [KSUID::Configuration] the gem's configuration
   def self.config
-    @config ||= KSUID::Configuration.new
+    @config ||= Configuration.new
   end
 
   # Configures the KSUID gem by passing a block
@@ -136,7 +136,6 @@ module KSUID
   # @param string [String] the base 62-encoded KSUID to convert into an object
   # @return [KSUID::Type] the KSUID generated from the string
   def self.from_base62(string)
-    string = string.rjust(STRING_LENGTH, Base62::CHARSET[0]) if string.length < STRING_LENGTH
     int = Base62.decode(string)
     bytes = Utils.int_to_bytes(int, 160)
 
@@ -155,10 +154,10 @@ module KSUID
   def self.from_bytes(bytes)
     bytes = bytes.bytes if bytes.is_a?(String)
 
-    timestamp = Utils.int_from_bytes(bytes.first(BYTES[:timestamp]))
-    payload = Utils.byte_string_from_array(bytes.last(BYTES[:payload]))
+    timestamp = Utils.int_from_bytes(bytes.first(BYTES.fetch(:timestamp)))
+    payload = Utils.byte_string_from_array(bytes.last(BYTES.fetch(:payload)))
 
-    KSUID::Type.new(payload: payload, time: Time.at(timestamp + EPOCH_TIME))
+    new(payload: payload, time: timestamp + EPOCH_TIME)
   end
 
   # Generates the maximum KSUID as a KSUID type
@@ -170,7 +169,7 @@ module KSUID
   #
   # @return [KSUID::Type] the maximum KSUID in both timestamp and payload
   def self.max
-    from_bytes([255] * BYTES[:total])
+    from_bytes([255] * BYTES.fetch(:total))
   end
 
   # Instantiates a new KSUID
@@ -198,9 +197,9 @@ module KSUID
   # @return [KSUID::Type] the converted KSUID
   def self.cast_string(ksuid)
     if Base62.compatible?(ksuid)
-      KSUID.from_base62(ksuid)
+      from_base62(ksuid)
     else
-      KSUID.from_bytes(ksuid)
+      from_bytes(ksuid)
     end
   end
   private_class_method :cast_string

--- a/lib/ksuid/activerecord/binary_type.rb
+++ b/lib/ksuid/activerecord/binary_type.rb
@@ -36,9 +36,7 @@ module KSUID
       # @param value [String, nil] the database-serialized KSUID to convert
       # @return [KSUID::Type] the deserialized KSUID
       def deserialize(value)
-        return unless value
-
-        value = value.to_s if value.is_a?(::ActiveRecord::Type::Binary::Data)
+        value = value.to_str if value.is_a?(Data)
         KSUID.call(value)
       end
 

--- a/lib/ksuid/backports.rb
+++ b/lib/ksuid/backports.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module KSUID
+  # Contains backports for recently added Ruby functionality
+  #
+  # @api private
+  module Backports
+    refine String do
+      unless ''.respond_to?(:unpack1)
+        # Decodes the string (which may contain binary data) according to the format string
+        #
+        # @api public
+        #
+        # @see https://ruby-doc.org/core-2.5.1/String.html#method-i-unpack1
+        # @see https://ruby-doc.org/core-2.5.1/String.html#method-i-unpack
+        #
+        # @param format [String] the format string for what to unpack
+        # @return [String] the first value extracted
+        def unpack1(format)
+          unpack(format).first
+        end
+      end
+    end
+  end
+end

--- a/lib/ksuid/base62.rb
+++ b/lib/ksuid/base62.rb
@@ -70,8 +70,7 @@ module KSUID
     def self.encode(number)
       chars = encode_without_padding(number)
 
-      chars << padding if chars.empty?
-      chars.reverse.join('').rjust(STRING_LENGTH, padding)
+      chars.reverse.join.rjust(STRING_LENGTH, padding)
     end
 
     # Encodes a byte string or byte array into base 62

--- a/lib/ksuid/configuration.rb
+++ b/lib/ksuid/configuration.rb
@@ -22,7 +22,7 @@ module KSUID
     #
     # @return [Proc]
     def self.default_generator
-      -> { SecureRandom.random_bytes(BYTES[:payload]) }
+      -> { SecureRandom.random_bytes(BYTES.fetch(:payload)) }
     end
 
     # Instantiates a new KSUID configuration
@@ -85,7 +85,7 @@ module KSUID
     # @raise [ConfigurationError] if the generator generates the wrong size payload
     # @return [nil]
     def assert_payload_size(generator)
-      return if (length = generator.call.length) == (expected_length = BYTES[:payload])
+      return if (length = generator.call.length).equal?(expected_length = BYTES.fetch(:payload))
 
       raise ConfigurationError, 'Random generator generates the wrong number of bytes ' \
         "(#{length} generated, #{expected_length} expected)"

--- a/lib/ksuid/type.rb
+++ b/lib/ksuid/type.rb
@@ -35,7 +35,7 @@ module KSUID
     # @return [KSUID::Type] the generated KSUID
     def initialize(payload: nil, time: Time.now)
       payload ||= KSUID.config.random_generator.call
-      byte_encoding = Utils.int_to_bytes(time.to_i - EPOCH_TIME)
+      byte_encoding = Utils.int_to_bytes(Integer(time) - EPOCH_TIME)
 
       @uid = byte_encoding.bytes + payload.bytes
     end
@@ -60,7 +60,7 @@ module KSUID
     # @param other [KSUID::Type] the other KSUID to check against
     # @return [Boolean]
     def ==(other)
-      other.to_s == to_s
+      to_s.eql?(other.to_s)
     end
 
     # Prints the KSUID for debugging within a console
@@ -88,7 +88,7 @@ module KSUID
     #
     # @return [String] a hex-encoded string
     def payload
-      Utils.bytes_to_hex_string(uid.last(BYTES[:payload]))
+      Utils.bytes_to_hex_string(uid.last(BYTES.fetch(:payload)))
     end
 
     # The KSUID as a hex-encoded string
@@ -132,9 +132,7 @@ module KSUID
     #
     # @return [Integer] the Unix timestamp for the event (without the epoch shift)
     def to_i
-      unix_time = Utils.int_from_bytes(uid.first(BYTES[:timestamp]))
-
-      unix_time
+      Utils.int_from_bytes(uid.first(BYTES.fetch(:timestamp)))
     end
 
     # The KSUID as a base 62-encoded string

--- a/lib/ksuid/utils.rb
+++ b/lib/ksuid/utils.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require_relative 'backports'
+
 module KSUID
   # Utility functions for converting between different encodings
   #
   # @api private
   module Utils
+    using Backports
+
     # Converts a byte string into a byte array
     #
     # @param bytes [String] a byte string
@@ -21,8 +25,7 @@ module KSUID
       bytes = bytes.bytes if bytes.is_a?(String)
 
       byte_string_from_array(bytes)
-        .unpack('H*')
-        .first
+        .unpack1('H*')
         .upcase
     end
 
@@ -35,7 +38,7 @@ module KSUID
 
       bytes
         .map { |byte| byte.to_s(2).rjust(8, '0') }
-        .join('')
+        .join
         .to_i(2)
     end
 
@@ -47,7 +50,7 @@ module KSUID
     def self.int_to_bytes(int, bits = 32)
       int
         .to_s(2)
-        .rjust(bits, '0')
+        .rjust(bits)
         .split('')
         .each_slice(8)
         .map { |digits| digits.join.to_i(2) }

--- a/spec/activerecord/binary_type_spec.rb
+++ b/spec/activerecord/binary_type_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails'
+require 'active_record'
+
+require 'ksuid/activerecord'
+
+RSpec.describe KSUID::ActiveRecord::BinaryType do
+  subject(:type) { described_class.new }
+
+  describe '#cast' do
+    it 'returns nil when given nil' do
+      expect(type.cast(nil)).to be(nil)
+    end
+
+    it 'converts to a KSUID' do
+      expect(type.cast("\xFF" * 20)).to eq(KSUID.max)
+    end
+  end
+
+  describe '#deserialize' do
+    it 'returns nil when given nil' do
+      expect(type.deserialize(nil)).to be(nil)
+    end
+
+    it 'converts to a KSUID' do
+      value = ActiveRecord::Type::Binary::Data.new(KSUID.max.to_bytes)
+      weird_type = Class.new(ActiveRecord::Type::Binary::Data)
+      other_value = weird_type.new(KSUID.max.to_bytes)
+
+      expect(type.deserialize(value)).to eq(KSUID.max)
+      expect(type.deserialize(other_value)).to eq(KSUID.max)
+      expect(type.deserialize(KSUID.max.to_bytes)).to eq(KSUID.max)
+      expect(type.deserialize(KSUID.max.to_bytes.bytes)).to eq(KSUID.max)
+    end
+  end
+
+  describe '#serialize' do
+    it 'returns nil when given nil' do
+      expect(type.serialize(nil)).to be(nil)
+    end
+
+    it 'converts to a binary-encoded KSUID' do
+      max_value = [255] * 20
+
+      expect(type.serialize(KSUID.max)).to be_an(ActiveModel::Type::Binary::Data)
+      expect(type.serialize(KSUID.max).to_s.bytes).to eq(max_value)
+      expect(type.serialize(KSUID.max.to_bytes).to_s.bytes).to eq(max_value)
+      expect(type.serialize(KSUID::MAX_STRING_ENCODED).to_s.bytes).to eq(max_value)
+    end
+  end
+
+  describe '#type' do
+    subject { type.type }
+
+    it { is_expected.to eq(:ksuid_binary) }
+  end
+end

--- a/spec/activerecord/table_definition_spec.rb
+++ b/spec/activerecord/table_definition_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails'
+require 'active_record'
+
+require 'ksuid/activerecord'
+require 'ksuid/activerecord/table_definition'
+
+RSpec.describe KSUID::ActiveRecord::TableDefinition do
+  let(:connection) do
+    ActiveRecord::Base.sqlite3_connection(
+      database: ':memory:',
+      adapter: 'sqlite3',
+      timeout: 100
+    )
+  end
+
+  describe '#ksuid' do
+    it 'defines a string-serialized KSUID column' do
+      connection.create_table(:string_ksuid_events, force: true) do |table|
+        table.ksuid :ksuid, index: true, unique: true, null: false
+      end
+
+      column = connection.columns('string_ksuid_events').find { |col| col.name == 'ksuid' }
+
+      expect(column.limit).to eq(27)
+      expect(column.null).to be(false)
+      expect(column.type).to eq(:string)
+    end
+  end
+
+  describe '#ksuid_binary' do
+    it 'defines a string-serialized KSUID column' do
+      connection.create_table(:binary_ksuid_events, force: true) do |table|
+        table.ksuid_binary :ksuid, index: true, unique: true, null: false
+      end
+
+      column = connection.columns('binary_ksuid_events').find { |col| col.name == 'ksuid' }
+
+      expect(column.limit).to eq(20)
+      expect(column.null).to be(false)
+      expect(column.type).to eq(:binary)
+    end
+  end
+
+  def with_example_table(definition = nil, table_name = 'ex')
+    definition ||=
+      <<-SQL
+        id integer PRIMARY KEY AUTOINCREMENT,
+        number integer
+      SQL
+
+    connection.execute("CREATE TABLE #{table_name}(#{definition})")
+
+    yield if block_given?
+  ensure
+    connection.execute("DROP TABLE #{table_name}")
+  end
+end

--- a/spec/activerecord/type_spec.rb
+++ b/spec/activerecord/type_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails'
+require 'active_record'
+
+require 'ksuid/activerecord'
+
+RSpec.describe KSUID::ActiveRecord::Type do
+  subject(:type) { described_class.new }
+
+  describe '#cast' do
+    it 'returns nil when given nil' do
+      expect(type.cast(nil)).to be(nil)
+    end
+
+    it 'converts to a KSUID' do
+      expect(type.cast(KSUID::MAX_STRING_ENCODED)).to eq(KSUID.max)
+    end
+  end
+
+  describe '#deserialize' do
+    it 'returns nil when given nil' do
+      expect(type.deserialize(nil)).to be(nil)
+    end
+
+    it 'converts to a KSUID' do
+      expect(type.deserialize(KSUID::MAX_STRING_ENCODED)).to eq(KSUID.max)
+    end
+  end
+
+  describe '#serialize' do
+    it 'returns nil when given nil' do
+      expect(type.serialize(nil)).to be(nil)
+    end
+
+    it 'converts to a string-encoded KSUID' do
+      expect(type.serialize(KSUID.max)).to be_a(String)
+      expect(type.serialize(KSUID.max)).to eq(KSUID::MAX_STRING_ENCODED)
+      expect(type.serialize(KSUID.max.to_bytes)).to eq(KSUID::MAX_STRING_ENCODED)
+      expect(type.serialize(KSUID::MAX_STRING_ENCODED)).to eq(KSUID::MAX_STRING_ENCODED)
+    end
+  end
+
+  describe '#type' do
+    subject { type.type }
+
+    it { is_expected.to eq(:ksuid) }
+  end
+end

--- a/spec/activerecord_spec.rb
+++ b/spec/activerecord_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails'
+require 'active_record'
+
+require 'ksuid/activerecord'
+
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.logger = Logger.new(IO::NULL)
+ActiveRecord::Schema.verbose = false
+
+ActiveRecord::Schema.define do
+  create_table :events, force: true do |t|
+    t.string :ksuid, index: true, unique: true
+  end
+
+  create_table :event_primary_keys, force: true, id: false do |t|
+    t.ksuid :id, primary_key: true
+  end
+
+  create_table :event_binaries, force: true do |t|
+    t.ksuid_binary :ksuid, index: true, unique: true
+  end
+end
+
+# A demonstration model for testing KSUID::ActiveRecord
+class Event < ActiveRecord::Base
+  include KSUID::ActiveRecord[:ksuid, created_at: true]
+end
+
+# A demonstration of KSUIDs as the primary key on a record
+class EventPrimaryKey < ActiveRecord::Base
+  include KSUID::ActiveRecord[:id]
+end
+
+# A demonstration of KSUIDs persisted as binaries
+class EventBinary < ActiveRecord::Base
+  include KSUID::ActiveRecord[:ksuid, binary: true]
+end
+
+ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+
+RSpec.describe KSUID::ActiveRecord do
+  context 'with a non-primary field as the KSUID' do
+    after { Event.delete_all }
+
+    it 'generates a KSUID upon initialization' do
+      event = Event.new
+
+      expect(event.ksuid).to be_a(KSUID::Type)
+    end
+
+    it 'restores a KSUID from the database' do
+      ksuid = Event.create!.ksuid
+      event = Event.find_by!(ksuid: ksuid)
+
+      expect(event.ksuid).to eq(ksuid)
+    end
+
+    it 'can be used as a timestamp for the created_at' do
+      event = Event.create!
+
+      expect(event.created_at).not_to be_nil
+    end
+
+    it 'can be looked up via a string, byte array, or KSUID' do
+      id = KSUID.new
+      event = Event.create!(ksuid: id)
+
+      expect(Event.find_by(ksuid: id.to_s)).to eq(event)
+      expect(Event.find_by(ksuid: id.to_bytes)).to eq(event)
+      expect(Event.find_by(ksuid: id)).to eq(event)
+    end
+  end
+
+  context 'with a primary key field as the KSUID' do
+    after { EventPrimaryKey.delete_all }
+
+    it 'generates a KSUID upon initialization' do
+      event = EventPrimaryKey.new
+
+      expect(event.id).to be_a(KSUID::Type)
+    end
+  end
+
+  context 'with a binary KSUID field' do
+    after { EventBinary.delete_all }
+
+    it 'generates a KSUID upon initialization' do
+      event = EventBinary.new
+
+      expect(event.ksuid).to be_a(KSUID::Type)
+    end
+
+    it 'persists the KSUID to the database' do
+      event = EventBinary.create!
+
+      expect(event.ksuid).to be_a(KSUID::Type)
+    end
+  end
+end

--- a/spec/base62_spec.rb
+++ b/spec/base62_spec.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe KSUID::Base62 do
-  describe '#decode' do
+  # Allow us to use mutation testing without ActiveSupport causing strange failures.
+  before do
+    String.send(:undef_method, :at) if ''.respond_to?(:at)
+  end
+
+  describe '.compatible?' do
+    it 'detects when a string is incompatible' do
+      expect(described_class.compatible?('15Ew2nYerDscBipuJicYjl970D1')).to be(true)
+      expect(described_class.compatible?('!')).to be(false)
+    end
+  end
+
+  describe '.decode' do
     it 'decodes base 62 numbers that may or may not be zero-padded' do
       %w[awesomesauce 00000000awesomesauce].each do |encoded|
         decoded = KSUID::Base62.decode(encoded)
@@ -27,11 +39,14 @@ RSpec.describe KSUID::Base62 do
     end
 
     it 'does bad things for words that are not base 62' do
-      expect { KSUID::Base62.decode('this should break!') }.to raise_error(ArgumentError)
+      expect { KSUID::Base62.decode('this should break!') }.to raise_error(
+        ArgumentError,
+        'this should break! is not a base 62 number'
+      )
     end
   end
 
-  describe '#encode' do
+  describe '.encode' do
     it 'encodes numbers into 27-digit base 62' do
       number = 1_922_549_000_510_644_890_748
 
@@ -47,9 +62,15 @@ RSpec.describe KSUID::Base62 do
 
       expect(encoded).to eq('000000000000000000000000000')
     end
+
+    it 'encode numbers with padding' do
+      encoded = KSUID::Base62.encode(1)
+
+      expect(encoded).to eq('000000000000000000000000001')
+    end
   end
 
-  describe '#encode_bytes' do
+  describe '.encode_bytes' do
     it 'encodes byte strings' do
       bytes = "\xFF" * 4
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe KSUID::Configuration do
   describe '#random_generator' do
-    it 'defaults to using secure random' do
+    it 'uses to the default generator when not set' do
       config = described_class.new
 
       random = config.random_generator.call
@@ -23,16 +23,18 @@ RSpec.describe KSUID::Configuration do
       config = described_class.new
 
       expect { config.random_generator = 'Hello' }.to raise_error(
-        KSUID::Configuration::ConfigurationError
+        KSUID::Configuration::ConfigurationError,
+        'Random generator Hello is not callable'
       )
     end
 
     it 'cannot be overriden by a generator of the wrong length' do
       config = described_class.new
-      short_generator = -> { Random.new.bytes(5) }
+      short_generator = -> { [0, 0, 0, 0, 0] }
 
       expect { config.random_generator = short_generator }.to raise_error(
-        KSUID::Configuration::ConfigurationError
+        KSUID::Configuration::ConfigurationError,
+        'Random generator generates the wrong number of bytes (5 generated, 16 expected)'
       )
     end
   end

--- a/spec/ksuid_spec.rb
+++ b/spec/ksuid_spec.rb
@@ -5,14 +5,6 @@ RSpec.describe KSUID do
     expect(KSUID::VERSION).not_to be nil
   end
 
-  it 'is configurable' do
-    generator = -> { "\x00" * KSUID::BYTES[:payload] }
-
-    KSUID.configure { |config| config.random_generator = generator }
-
-    expect(KSUID.config.random_generator).to eq(generator)
-  end
-
   describe '.call' do
     it 'returns KSUIDs in tact' do
       ksuid = KSUID.new
@@ -53,7 +45,108 @@ RSpec.describe KSUID do
     end
 
     it 'raise an ArgumentError upon an unknown value' do
-      expect { KSUID.call(1) }.to raise_error(ArgumentError)
+      expect { KSUID.call(1) }.to raise_error(ArgumentError, 'Cannot convert 1 to KSUID')
+    end
+  end
+
+  describe '.configure' do
+    it 'returns a configuration even without a block' do
+      expect(KSUID.configure).to be_a(KSUID::Configuration)
+    end
+
+    it 'sets configuration values via the block' do
+      generator = -> { "\x00" * KSUID::BYTES[:payload] }
+
+      KSUID.configure { |config| config.random_generator = generator }
+
+      expect(KSUID.config.random_generator).to eq(generator)
+    end
+  end
+
+  describe '.from_base62' do
+    it 'converts a base62 KSUID properly' do
+      ksuid = KSUID.from_base62(KSUID::MAX_STRING_ENCODED)
+
+      expect(ksuid).to eq(KSUID.max)
+    end
+
+    it 'converts a too-short, but correct KSUID' do
+      ksuid = KSUID.from_base62('07B4A17')
+
+      expect(ksuid).to eq('0000000000000000000007B4A17')
+    end
+  end
+
+  describe '.from_bytes' do
+    it 'converts a list of bytes' do
+      bytes = [
+        6, 131, 247, 137, 4, 156, 194, 21, 192, 153,
+        212, 43, 120, 77, 190, 153, 52, 27, 215, 156
+      ]
+      expected = '0vdbMgWkU6slGpLVCqEFwkkZvuW'
+
+      ksuid = KSUID.from_bytes(bytes)
+
+      expect(ksuid).to eq(expected)
+    end
+
+    it 'converts a subclass of String' do
+      weird = Class.new(String)
+      value = weird.new("\x06\x83\xF7\x89\x04\x9C\xC2\x15\xC0\x99\xD4+xM\xBE\x994\e\xD7\x9C")
+      expected = '0vdbMgWkU6slGpLVCqEFwkkZvuW'
+
+      ksuid = KSUID.from_bytes(value)
+
+      expect(ksuid).to eq(expected)
+    end
+  end
+
+  describe '.new' do
+    it 'uses the timestamp when specified' do
+      payload = "\x00" * 16
+      now = Time.parse('2018-06-17 18:00:39 -0500')
+
+      ksuid = KSUID.new(payload: payload, time: now)
+
+      expect(ksuid.raw).to eq('07B49A1700000000000000000000000000000000')
+      expect(ksuid.to_s).to eq('16AHMjcX2q0H9rmWgWQwL0hb58q')
+      expect(ksuid.to_time).to eq(now)
+    end
+
+    it 'defaults the timestamp to now' do
+      payload = "\x00" * 16
+      now = Time.parse('2018-06-17 18:00:39 -0500')
+
+      Timecop.freeze(now) do
+        ksuid = KSUID.new(payload: payload)
+
+        expect(ksuid.raw).to eq('07B49A1700000000000000000000000000000000')
+        expect(ksuid.to_s).to eq('16AHMjcX2q0H9rmWgWQwL0hb58q')
+        expect(ksuid.to_time).to eq(now)
+      end
+    end
+
+    context 'with a static random generator' do
+      around(:each) do |example|
+        original_generator = KSUID.config.random_generator
+        KSUID.config.random_generator = -> { "\xFF" * 16 }
+
+        example.run
+
+        KSUID.config.random_generator = original_generator
+      end
+
+      it 'generates a payload when one is not given' do
+        now = Time.parse('2018-06-17 18:00:39 -0500')
+
+        Timecop.freeze(now) do
+          ksuid = KSUID.new
+
+          expect(ksuid.raw).to eq('07B49A17FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF')
+          expect(ksuid.to_s).to eq('16AHMrPb53GdFLSIQgE57toqmkx')
+          expect(ksuid.to_time).to eq(now)
+        end
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,10 @@ end
 
 require 'ksuid'
 
+Dir[Pathname.new(File.expand_path('support', __dir__)) / '**' / '*.rb'].each do |support_file|
+  require support_file
+end
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.syntax = :expect

--- a/spec/support/mutant.rb
+++ b/spec/support/mutant.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+if ENV['MUTANT']
+  RSpec.configure do |config|
+    config.around(:each) do |example|
+      Timeout.timeout(1, &example)
+    end
+  end
+end

--- a/spec/support/timecop.rb
+++ b/spec/support/timecop.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'timecop'
+
+Timecop.safe_mode = true

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -1,22 +1,46 @@
 # frozen_string_literal: true
 
 RSpec.describe KSUID::Type do
-  describe '.from_base62' do
-    it 'converts a base62 KSUID properly' do
-      ksuid = KSUID.from_base62(KSUID::MAX_STRING_ENCODED)
+  describe '#initialize' do
+    it 'generates a payload when one is not passed' do
+      expect(KSUID::Type.new.payload).not_to be_nil
+      expect(KSUID::Type.new(payload: nil).payload).not_to be_nil
+    end
 
-      expect(ksuid).to eq(KSUID.max)
+    it 'generates a timestamp when one is not passed' do
+      now = Time.parse('2018-06-17 23:10:20 -0500')
+      payload = "\xFF" * 16
+      expected = '16At1su4a88N9Mg0fSgwq6a4umV'
+
+      Timecop.freeze(now) do
+        expect(KSUID::Type.new(payload: payload).to_s).to eq(expected)
+      end
     end
   end
 
   describe '#<=>' do
     it 'sorts the KSUIDs by timestamp' do
-      ksuid1 = KSUID.new(time: Time.now)
-      ksuid2 = KSUID.new(time: Time.now + 1)
+      Timecop.freeze do
+        ksuid1 = KSUID.new(time: Time.now)
+        ksuid2 = KSUID.new(time: Time.now + 1)
 
-      array = [ksuid2, ksuid1].sort
+        array = [ksuid2, ksuid1].sort
 
-      expect(array).to eq([ksuid1, ksuid2])
+        expect(array).to eq([ksuid1, ksuid2])
+        expect(ksuid1 <=> ksuid2).to eq(-1)
+        expect(ksuid1 <=> ksuid1).to eq(0) # rubocop:disable Lint/UselessComparison
+        expect(ksuid2 <=> ksuid1).to eq(1)
+      end
+    end
+  end
+
+  describe '#==' do
+    it 'works' do
+      ksuid = KSUID.max
+
+      expect(ksuid == 'aWgEPTl1tmebfsQzFP4bxwgy80V').to be(true)
+      expect(ksuid == KSUID.max).to be(true)
+      expect(ksuid == '').to be(false)
     end
   end
 
@@ -24,25 +48,34 @@ RSpec.describe KSUID::Type do
     it 'shows the string representation for easy understanding' do
       ksuid = KSUID.max
 
-      expect(ksuid.inspect).to match('aWgEPTl1tmebfsQzFP4bxwgy80V')
+      expect(ksuid.inspect).to eq('<KSUID(aWgEPTl1tmebfsQzFP4bxwgy80V)>')
     end
   end
 
   describe '#payload' do
     it 'returns the payload as a byte string' do
-      expected = 'F' * 32
+      bytes = KSUID.from_base62('16AFlKJgs5TiMSZwUrJWyfIznLI').payload
 
-      array = KSUID.max.payload
+      expect(bytes).to eq('F536AD71E1815D2202FD994175B3DA04')
+    end
+  end
 
-      expect(array).to eq(expected)
+  describe '#raw' do
+    it 'returns the payload as a hex-encoded string' do
+      hex = KSUID.from_base62('16AFlKJgs5TiMSZwUrJWyfIznLI').raw
+
+      expect(hex).to eq('07B496FFF536AD71E1815D2202FD994175B3DA04')
     end
   end
 
   describe '#to_bytes' do
     it 'returns the ksuid as a byte string' do
-      expected = ("\xFF" * 20).bytes
+      expected = [
+        7, 180, 150, 255, 245, 54, 173, 113, 225, 129, 93, 34, 2, 253, 153, 65,
+        117, 179, 218, 4
+      ]
 
-      array = KSUID.max.to_bytes.bytes
+      array = KSUID.from_base62('16AFlKJgs5TiMSZwUrJWyfIznLI').to_bytes.bytes
 
       expect(array).to eq(expected)
     end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -9,6 +9,33 @@ RSpec.describe KSUID::Utils do
     expect(converted_number).to eq(number)
   end
 
+  describe '#bytes_to_hex_string' do
+    it 'converts a byte string to its hex equivalent' do
+      byte_string = "\xAA\xBB\xCC\xDD\xEE\xFF"
+
+      converted_number = KSUID::Utils.bytes_to_hex_string(byte_string)
+
+      expect(converted_number).to eq('AABBCCDDEEFF')
+    end
+
+    it 'converts a byte array to its hex equivalent' do
+      byte_array = [255] * 4
+
+      converted_number = KSUID::Utils.bytes_to_hex_string(byte_array)
+
+      expect(converted_number).to eq('FFFFFFFF')
+    end
+
+    it 'converts a subclassed string to its hex equivalent' do
+      weird_class = Class.new(String)
+      byte_string = weird_class.new("\xFF" * 4)
+
+      converted_number = KSUID::Utils.bytes_to_hex_string(byte_string)
+
+      expect(converted_number).to eq('FFFFFFFF')
+    end
+  end
+
   describe '#int_from_bytes' do
     it 'converts a byte string to an integer' do
       number_from_binary = ('1' * 32).to_i(2)
@@ -35,6 +62,16 @@ RSpec.describe KSUID::Utils do
 
       expect(converted).to eq(expected)
     end
+
+    it 'converts a subclassed string to an integer' do
+      weird_class = Class.new(String)
+      number_from_binary = ('1' * 32).to_i(2)
+      byte_string = weird_class.new("\xFF" * 4)
+
+      converted_number = KSUID::Utils.int_from_bytes(byte_string)
+
+      expect(converted_number).to eq(number_from_binary)
+    end
   end
 
   describe '#int_to_bytes' do
@@ -43,6 +80,14 @@ RSpec.describe KSUID::Utils do
       expected = ("\xFF" * 4).bytes
 
       converted_bytes = KSUID::Utils.int_to_bytes(number_from_binary).bytes
+
+      expect(converted_bytes).to eq(expected)
+    end
+
+    it 'converts integers of other sizes' do
+      expected = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 180, 147, 249]
+
+      converted_bytes = KSUID::Utils.int_to_bytes(129_274_873, 160).bytes
 
       expect(converted_bytes).to eq(expected)
     end


### PR DESCRIPTION
There are a few mutation failures that are causing problems around
ActiveRecord. I cannot figure out how to filter them out, so we're left
with ~99.7% mutation coverage.

Note that this requires a patch that I submitted upstream that has been
merged, but not released as a new version yet. As such, we have that
commit locked in the Gemfile.

There is also a weird method removal within the Base62 tests that
removes an addition from ActiveSupport. This library should not rely on
ActiveSupport, so we cannot make that change to fail the mutation ... so
we undefine the method and let that handle the problem.