### PR TITLE
Support `id: :ksuid` in create_table

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,8 @@ end
 group :development, :test do
   gem 'pry'
   gem 'rake', '< 11'
+  gem 'rails'
+  gem 'sqlite3'
 end
 
 group :ci do

--- a/README.md
+++ b/README.md
@@ -160,7 +160,27 @@ You can also use a KSUID as the primary key on a table, much like you can use a 
 class CreateEvents < ActiveRecord::Migration[5.2]
   create_table :events, id: false do |table|
     table.ksuid :id, primary_key: true
+    table.timestamps
   end
+end
+```
+
+Alternatively it's possible to specify `id: :ksuid` directly.
+
+```ruby
+class CreateEvents < ActiveRecord::Migration[5.2]
+  create_table :events, id: :ksuid do |table|
+    table.timestamps
+  end
+end
+```
+
+To automatically use KSUID as primary key, create the following initializer:
+
+```ruby
+# config/initializers/ksuid.rb
+Rails.application.config.generators do |g|
+  g.orm :active_record, primary_key_type: :ksuid
 end
 ```
 

--- a/ksuid.gemspec
+++ b/ksuid.gemspec
@@ -17,6 +17,4 @@ Gem::Specification.new do |spec|
   spec.files += %w[ksuid.gemspec]
   spec.files += Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
-
-  spec.add_development_dependency 'bundler', '~> 1.15'
 end

--- a/lib/ksuid/activerecord/schema_statements.rb
+++ b/lib/ksuid/activerecord/schema_statements.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module KSUID
+  module SchemaStatements
+    module NativeDatabaseTypes
+      def self.configure
+        env_config = ::ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
+
+        if env_config.count > 0
+          env_config.each do |c|
+            case c.config["adapter"].to_sym
+            when :postgresql
+              load_postgresql
+            when :sqlite3
+              load_sqlite3
+            when :mysql
+              load_mysql
+            end
+          end
+        else
+          load_postgresql
+          load_sqlite3
+          load_mysql
+        end
+      end
+
+      def self.load_postgresql
+        require "active_record/connection_adapters/postgresql_adapter"
+        ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:ksuid] = {
+          name: "character varying",
+          limit: 27,
+        }
+      end
+
+      def self.load_sqlite3
+        require "active_record/connection_adapters/sqlite3_adapter"
+        ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:ksuid] = {
+          name: "varchar",
+          limit: 27,
+        }
+      end
+
+      def self.load_mysql
+        require "active_record/connection_adapters/abstract_mysql_adapter"
+        ::ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:ksuid] = {
+          name: "varchar",
+          limit: 27,
+        }
+      end
+    end
+  end
+end
+
+KSUID::SchemaStatements::NativeDatabaseTypes.configure

--- a/lib/ksuid/railtie.rb
+++ b/lib/ksuid/railtie.rb
@@ -5,10 +5,11 @@ module KSUID
   #
   # @api private
   class Railtie < ::Rails::Railtie
-    initializer 'ksuid' do
+    initializer "ksuid" do
       ActiveSupport.on_load :active_record do
-        require 'ksuid/activerecord'
-        require 'ksuid/activerecord/table_definition'
+        require "ksuid/activerecord"
+        require "ksuid/activerecord/table_definition"
+        require "ksuid/activerecord/schema_statements"
       end
     end
   end


### PR DESCRIPTION
```ruby
class CreateEvents < ActiveRecord::Migration[5.2]
  create_table :events, id: :ksuid do |table|
    table.timestamps
  end
end
```

