### PR TITLE
act_as_ksuid

### DIFF
--- a/lib/ksuid/activerecord.rb
+++ b/lib/ksuid/activerecord.rb
@@ -9,8 +9,12 @@ module KSUID
     extend ActiveSupport::Concern
 
     class_methods do
-      def act_as_ksuid(field = :id)
-        self.send(:attribute, field.to_sym, :ksuid, default: -> { KSUID.new })
+      def act_as_ksuid(field = :id, opts = {})
+        if opts[:binary]
+          self.send(:attribute, field.to_sym, :ksuid_binary, default: -> { KSUID.new })
+        else
+          self.send(:attribute, field.to_sym, :ksuid, default: -> { KSUID.new })
+        end
 
         self.instance_eval do
           define_method "#{field.to_s}_created_at" do

--- a/lib/ksuid/activerecord.rb
+++ b/lib/ksuid/activerecord.rb
@@ -1,75 +1,27 @@
 # frozen_string_literal: true
 
-require 'ksuid/activerecord/binary_type'
-require 'ksuid/activerecord/type'
+require "ksuid/activerecord/binary_type"
+require "ksuid/activerecord/type"
 
 module KSUID
   # Enables an Active Record model to have a KSUID attribute
-  #
-  # @api public
-  module ActiveRecord
-    # Builds a module to include into the model
-    #
-    # @api public
-    #
-    # @example Add a `#ksuid` attribute to a model
-    #   class Event < ActiveRecord::Base
-    #     include KSUID::ActiveRecord[:ksuid]
-    #   end
-    #
-    # @example Add a `#remote_id` attribute to a model and overrides `#created_at` to use the KSUID
-    #   class Event < ActiveRecord::Base
-    #     include KSUID::ActiveRecord[:remote_id, created_at: true]
-    #   end
-    #
-    # @param field [String, Symbol] the name of the field to use as a KSUID
-    # @param created_at [Boolean] whether to override the `#created_at` method
-    # @param binary [Boolean] whether to store the KSUID as a binary or a string
-    # @return [Module] the module to include into the model
-    def self.[](field, created_at: false, binary: false)
-      Module
-        .new
-        .tap do |mod|
-          define_attribute(field, mod, binary)
-          define_created_at(field, mod) if created_at
+  module ActiveRecordExtension
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def act_as_ksuid(field = :id)
+        self.send(:attribute, field.to_sym, :ksuid, default: -> { KSUID.new })
+
+        self.instance_eval do
+          define_method "#{field.to_s}_created_at" do
+            k = self.send(field)
+            return nil unless k
+            k.to_time
+          end
         end
+      end
     end
-
-    # Defines the attribute method that will be written in the module
-    #
-    # @api private
-    #
-    # @param field [String, Symbol] the name of the field to set as an attribute
-    # @param mod [Module] the module to extend
-    # @return [void]
-    def self.define_attribute(field, mod, binary)
-      type = 'ksuid'
-      type = 'ksuid_binary' if binary
-
-      mod.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def self.included(base)
-          base.__send__(:attribute, :#{field}, :#{type}, default: -> { KSUID.new })
-        end
-      RUBY
-    end
-    private_class_method :define_attribute
-
-    # Defines the `#created_at` method that will be written in the module
-    #
-    # @api private
-    #
-    # @param field [String, Symbol] the name of the KSUID attribute field
-    # @param mod [Module] the module to extend
-    # @return [void]
-    def self.define_created_at(field, mod)
-      mod.module_eval <<-RUBY, __FILE__, __LINE__ + 1
-        def created_at
-          return unless #{field}
-
-          #{field}.to_time
-        end
-      RUBY
-    end
-    private_class_method :define_created_at
   end
 end
+
+ActiveRecord::Base.send(:include, KSUID::ActiveRecordExtension)

--- a/spec/railtie_spec.rb
+++ b/spec/railtie_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require 'rails'
-require 'active_record'
-require 'logger'
+require "rails"
+require "active_record"
+require "logger"
 
-require 'ksuid/activerecord'
-require 'ksuid/activerecord/table_definition'
+require "ksuid/activerecord"
+require "ksuid/activerecord/table_definition"
 
-ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
 ActiveRecord::Base.logger = Logger.new(IO::NULL)
 ActiveRecord::Schema.verbose = false
 
@@ -27,45 +27,45 @@ end
 
 # A demonstration model for testing KSUID::ActiveRecord
 class Event < ActiveRecord::Base
-  include KSUID::ActiveRecord[:ksuid, created_at: true]
+  act_as_ksuid :ksuid
 end
 
 # A demonstration of KSUIDs as the primary key on a record
 class EventPrimaryKey < ActiveRecord::Base
-  include KSUID::ActiveRecord[:id]
+  act_as_ksuid # assumes :id
 end
 
 # A demonstration of KSUIDs persisted as binaries
 class EventBinary < ActiveRecord::Base
-  include KSUID::ActiveRecord[:ksuid, binary: true]
+  act_as_ksuid :ksuid, binary: true
 end
 
 ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
 
-RSpec.describe 'ActiveRecord integration' do
-  context 'with a non-primary field as the KSUID' do
+RSpec.describe "ActiveRecord integration" do
+  context "with a non-primary field as the KSUID" do
     after { Event.delete_all }
 
-    it 'generates a KSUID upon initialization' do
+    it "generates a KSUID upon initialization" do
       event = Event.new
 
       expect(event.ksuid).to be_a(KSUID::Type)
     end
 
-    it 'restores a KSUID from the database' do
+    it "restores a KSUID from the database" do
       ksuid = Event.create!.ksuid
       event = Event.last
 
       expect(event.ksuid).to eq(ksuid)
     end
 
-    it 'can be used as a timestamp for the created_at' do
+    it "can be used as a timestamp for the created_at" do
       event = Event.create!
 
-      expect(event.created_at).not_to be_nil
+      expect(event.ksuid_created_at).not_to be_nil
     end
 
-    it 'can be looked up via a string, byte array, or KSUID' do
+    it "can be looked up via a string, byte array, or KSUID" do
       id = KSUID.new
       event = Event.create!(ksuid: id)
 
@@ -75,26 +75,26 @@ RSpec.describe 'ActiveRecord integration' do
     end
   end
 
-  context 'with a primary key field as the KSUID' do
+  context "with a primary key field as the KSUID" do
     after { EventPrimaryKey.delete_all }
 
-    it 'generates a KSUID upon initialization' do
+    it "generates a KSUID upon initialization" do
       event = EventPrimaryKey.new
 
       expect(event.id).to be_a(KSUID::Type)
     end
   end
 
-  context 'with a binary KSUID field' do
+  context "with a binary KSUID field" do
     after { EventBinary.delete_all }
 
-    it 'generates a KSUID upon initialization' do
+    it "generates a KSUID upon initialization" do
       event = EventBinary.new
 
       expect(event.ksuid).to be_a(KSUID::Type)
     end
 
-    it 'persists the KSUID to the database' do
+    it "persists the KSUID to the database" do
       event = EventBinary.create
 
       expect(event.ksuid).to be_a(KSUID::Type)


### PR DESCRIPTION
Turn `include KSUID::ActiveRecord[:id]` into:

```
act_as_ksuid # assumes :id
act_as_ksuid :id
act_as_ksuid :book_id
act_as_ksuid :book_id, binary: true
```

It will also automatically create:

```
id_created_at
book_id_created_at
```