### PR TITLE
Update the development harness and contributing instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
   - /^v\d+\.\d+(?:\.\d+)?(?:-\S*)?$/
 
 before_install:
-  - "gem update --system --no-doc --no-ri"
+  - "gem update --system --no-doc"
   - "gem install bundler"
 
 bundler_args: "--without development --with ci"

--- a/Appraisals
+++ b/Appraisals
@@ -3,17 +3,17 @@
 appraise 'rails-5.0' do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 50', platforms: %i[jruby]
   gem 'rails', '~> 5.0.0'
-  gem 'sqlite3', platforms: %i[mri mingw x64_mingw]
+  gem 'sqlite3', '~> 1.3.6', platforms: %i[mri mingw x64_mingw]
 end
 
 appraise 'rails-5.1' do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 51', platforms: %i[jruby]
   gem 'rails', '~> 5.1.0'
-  gem 'sqlite3', platforms: %i[mri mingw x64_mingw]
+  gem 'sqlite3', '~> 1.3', '>= 1.3.6', platforms: %i[mri mingw x64_mingw]
 end
 
 appraise 'rails-5.2' do
   gem 'activerecord-jdbcsqlite3-adapter', platforms: %i[jruby]
   gem 'rails', '~> 5.2.0'
-  gem 'sqlite3', platforms: %i[mri mingw x64_mingw]
+  gem 'sqlite3', '~> 1.3', '>= 1.3.6', platforms: %i[mri mingw x64_mingw]
 end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,14 +28,13 @@ Ideally, a bug report should include a pull request with failing specs.
 1. [Fork the repository].
 2. [Create a topic branch].
 3. Add specs for your unimplemented feature or bug fix.
-4. Run `bundle exec rake spec`. If your specs pass, return to step 3.
+4. Run `appraisal rake spec`. If your specs pass, return to step 3.
 5. Implement your feature or bug fix.
-6. Run `bundle exec rake`. If your specs or any of the linters fail, return to step 5.
+6. Run `appraisal rake`. If your specs or any of the linters fail, return to step 5.
 7. Open `coverage/index.html`. If your changes are not completely covered by your tests, return to step 3.
 8. Add documentation for your feature or bug fix.
-9. Run `bundle exec inch`. If your changes are below a B in documentation, go back to step 8.
-10. Commit and push your changes.
-11. [Submit a pull request].
+9. Commit and push your changes.
+10. [Submit a pull request].
 
 [Create a topic branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [Fork the repository]: http://learn.github.com/p/branching.html

--- a/Gemfile
+++ b/Gemfile
@@ -19,11 +19,11 @@ group :development do
   gem 'yard', '~> 0.9'
   gem 'yard-doctest'
   gem 'yardstick'
-end
 
-group :development, :test do
-  gem 'pry'
-  gem 'rake', '< 11'
+  group :test do
+    gem 'pry'
+    gem 'rake'
+  end
 end
 
 group :ci do

--- a/Rakefile
+++ b/Rakefile
@@ -81,5 +81,6 @@ if !ENV['APPRAISAL_INITIALIZED'] && !ENV['CI']
   Appraisal::Task.new
   task default: :appraisal
 else
+  ENV['COVERAGE'] = '1'
   task default: default
 end

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -19,11 +19,11 @@ group :development do
   gem "yard", "~> 0.9"
   gem "yard-doctest"
   gem "yardstick"
-end
 
-group :development, :test do
-  gem "pry"
-  gem "rake", "< 11"
+  group :test do
+    gem "pry"
+    gem "rake"
+  end
 end
 
 group :ci do

--- a/gemfiles/rails_5.0.gemfile
+++ b/gemfiles/rails_5.0.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord-jdbcsqlite3-adapter", "~> 50", platforms: [:jruby]
 gem "rails", "~> 5.0.0"
-gem "sqlite3", platforms: [:mri, :mingw, :x64_mingw]
+gem "sqlite3", "~> 1.3.6", platforms: [:mri, :mingw, :x64_mingw]
 
 group :development do
   gem "benchmark-ips"

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -19,11 +19,11 @@ group :development do
   gem "yard", "~> 0.9"
   gem "yard-doctest"
   gem "yardstick"
-end
 
-group :development, :test do
-  gem "pry"
-  gem "rake", "< 11"
+  group :test do
+    gem "pry"
+    gem "rake"
+  end
 end
 
 group :ci do

--- a/gemfiles/rails_5.1.gemfile
+++ b/gemfiles/rails_5.1.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord-jdbcsqlite3-adapter", "~> 51", platforms: [:jruby]
 gem "rails", "~> 5.1.0"
-gem "sqlite3", platforms: [:mri, :mingw, :x64_mingw]
+gem "sqlite3", "~> 1.3", ">= 1.3.6", platforms: [:mri, :mingw, :x64_mingw]
 
 group :development do
   gem "benchmark-ips"

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -19,11 +19,11 @@ group :development do
   gem "yard", "~> 0.9"
   gem "yard-doctest"
   gem "yardstick"
-end
 
-group :development, :test do
-  gem "pry"
-  gem "rake", "< 11"
+  group :test do
+    gem "pry"
+    gem "rake"
+  end
 end
 
 group :ci do

--- a/gemfiles/rails_5.2.gemfile
+++ b/gemfiles/rails_5.2.gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
 gem "rails", "~> 5.2.0"
-gem "sqlite3", platforms: [:mri, :mingw, :x64_mingw]
+gem "sqlite3", "~> 1.3", ">= 1.3.6", platforms: [:mri, :mingw, :x64_mingw]
 
 group :development do
   gem "benchmark-ips"

--- a/ksuid.gemspec
+++ b/ksuid.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.files += Dir['lib/**/*.rb']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'bundler', '>= 1.15'
 end


### PR DESCRIPTION
It had become burdensome to contribute to the gem because of changes in the ecosystem and in the development harness itself. These changes lessen the burden and make it easier to contribute.