### PR TITLE
Benchmark and adjust the Base62 charset check

### DIFF
--- a/benchmark/charset_inclusion.rb
+++ b/benchmark/charset_inclusion.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# A benchmark that tests different ways to ensure a string matches
+# only characters from the KSUID Base62 charset.
+
+require 'benchmark/ips'
+
+EXAMPLE = '15Ew2nYeRDscBipuJicYjl970D1'
+CHARSET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+MATCHER = /[^#{CHARSET}]/
+CHARS   = CHARSET.chars
+
+# Uses a two-finger method to check each character against each charset member
+# exactly once
+def two_finger(example)
+  example = example.chars.sort
+  left, right = [0, 0]
+
+  while left < example.length && right < CHARSET.length do
+    if example[left] == CHARSET[right]
+      left += 1
+    else
+      right += 1
+    end
+  end
+
+  left == example.length &&
+    example[left - 1] == CHARSET[right]
+end
+
+Benchmark.ips do |bench|
+  bench.report('include?') { EXAMPLE.each_char.all? { |c| CHARSET.include? c } }
+  bench.report('Regexp#match?') { !CHARSET.match?(EXAMPLE) }
+  bench.report('Array#-') { EXAMPLE.split('') - CHARS }
+  bench.report('two finger') { two_finger(EXAMPLE) }
+
+  bench.compare!
+end

--- a/lib/ksuid/base62.rb
+++ b/lib/ksuid/base62.rb
@@ -20,6 +20,11 @@ module KSUID
     # @api private
     BASE = CHARSET.size
 
+    # A matcher that checks whether a String has a character outside the charset
+    #
+    # @api private
+    MATCHER = /[^#{CHARSET}]/.freeze
+
     # Checks whether a string is a base 62-compatible string
     #
     # @api public
@@ -30,7 +35,7 @@ module KSUID
     # @param string [String] the string to check for compatibility
     # @return [Boolean]
     def self.compatible?(string)
-      string.each_char.all? { |char| CHARSET.include?(char) }
+      string.each_char.all? { |char| !MATCHER.match?(char) }
     end
 
     # Decodes a base 62-encoded string into an integer


### PR DESCRIPTION
I had a hunch that the way that we were checking for character presence in the Base62 class wasn't the most performant since it created an iterator with a block. Thus, this benchmark: it checks the four different ways that I could think of to perform this task.

Surprisingly, that was the second fastest way of doing it!

Using `Regexp#match?` is a little more than twice as fast as the current implementation, so I opted to make the switch. Included below are some timings on my laptop.

```
Warming up --------------------------------------
            include?    28.062k i/100ms
       Regexp#match?    68.160k i/100ms
             Array#-    10.556k i/100ms
          two finger     8.203k i/100ms
Calculating -------------------------------------
            include?    282.838k (± 0.6%) i/s -      1.431M in   5.060186s
       Regexp#match?    673.904k (± 0.9%) i/s -      3.408M in   5.057563s
             Array#-    104.379k (± 0.8%) i/s -    527.800k in   5.056886s
          two finger     79.321k (± 1.1%) i/s -    401.947k in   5.068036s

Comparison:
       Regexp#match?:   673903.6 i/s
            include?:   282838.5 i/s - 2.38x  (± 0.00) slower
             Array#-:   104379.4 i/s - 6.46x  (± 0.00) slower
          two finger:    79320.6 i/s - 8.50x  (± 0.00) slower
```