### PR TITLE
Add a utility function for converting hex to bytes

### DIFF
--- a/lib/ksuid/utils.rb
+++ b/lib/ksuid/utils.rb
@@ -5,12 +5,32 @@ module KSUID
   #
   # @api private
   module Utils
+    # A regular expression for splitting a String into pairs of characters
+    #
+    # @return [Regexp] the splitter
+    PAIRS = /.{2}/.freeze
+
     # Converts a byte string into a byte array
     #
     # @param bytes [String] a byte string
     # @return [Array<Integer>] an array of bytes from the byte string
     def self.byte_string_from_array(bytes)
       bytes.pack('C*')
+    end
+
+    # Converts a hex string into a byte string
+    #
+    # @param hex [String] a hex-encoded KSUID
+    # @param bits [Integer] the expected number of bits for the result
+    # @return [String] the byte string
+    def self.byte_string_from_hex(hex, bits = 32)
+      byte_array =
+        hex
+        .rjust(bits, '0')
+        .scan(PAIRS)
+        .map { |bytes| bytes.to_i(16) }
+
+      byte_string_from_array(byte_array)
     end
 
     # Converts a byte string or byte array into a hex-encoded string

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -9,6 +9,17 @@ RSpec.describe KSUID::Utils do
     expect(converted_number).to eq(number)
   end
 
+  describe '#byte_string_from_hex' do
+    it 'converts a hex string to an integer' do
+      hex = '0DE978D96CA064CB84C244311C261F49DB083AA8'
+
+      result = KSUID::Utils.byte_string_from_hex(hex)
+
+      expect(KSUID::Utils.bytes_to_hex_string(result)).to eq hex
+      expect(KSUID.call(result)).to eq KSUID.call('1z4PxXDcFiwInVMCTC3MvcbGptw')
+    end
+  end
+
   describe '#int_from_bytes' do
     it 'converts a byte string to an integer' do
       number_from_binary = ('1' * 32).to_i(2)


### PR DESCRIPTION
The reference implementation of KSUID handles KSUIDs as hex-encoded strings in some cases. It turns out that PostgreSQL also handles them in the same way. This function allows for easy conversion from that format.