### PR TITLE
Optimize Base62.compatible?

### DIFF
--- a/benchmark/charset_inclusion.rb
+++ b/benchmark/charset_inclusion.rb
@@ -4,9 +4,11 @@
 # only characters from the KSUID Base62 charset.
 
 require 'benchmark/ips'
+require 'set'
 
 EXAMPLE = '15Ew2nYeRDscBipuJicYjl970D1'
 CHARSET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
+CHARSET_SET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split.to_set
 MATCHER = /[^#{CHARSET}]/
 CHARS   = CHARSET.chars
 
@@ -30,7 +32,9 @@ end
 
 Benchmark.ips do |bench|
   bench.report('include?') { EXAMPLE.each_char.all? { |c| CHARSET.include? c } }
+  bench.report('include? optimized') { EXAMPLE.each_char.all? { |c| CHARSET_SET.include?(c) } }
   bench.report('Regexp#match?') { !CHARSET.match?(EXAMPLE) }
+  bench.report('Regexp#match? - commit cac33be') { EXAMPLE.each_char.all? { |c| !CHARSET.match?(MATCHER) } }
   bench.report('Array#-') { EXAMPLE.split('') - CHARS }
   bench.report('two finger') { two_finger(EXAMPLE) }
 

--- a/lib/ksuid/base62.rb
+++ b/lib/ksuid/base62.rb
@@ -15,15 +15,15 @@ module KSUID
     # @api private
     CHARSET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
 
+    # A Set of all base 62 characters used for optimized lookup
+    #
+    # @api private
+    CHARSET_SET = CHARSET.split.to_set
+
     # The base (62) that this module encodes numbers into
     #
     # @api private
     BASE = CHARSET.size
-
-    # A matcher that checks whether a String has a character outside the charset
-    #
-    # @api private
-    MATCHER = /[^#{CHARSET}]/.freeze
 
     # Checks whether a string is a base 62-compatible string
     #
@@ -35,7 +35,7 @@ module KSUID
     # @param string [String] the string to check for compatibility
     # @return [Boolean]
     def self.compatible?(string)
-      string.each_char.all? { |char| !MATCHER.match?(char) }
+      string.each_char.all? { |c| CHARSET_SET.include?(c) }
     end
 
     # Decodes a base 62-encoded string into an integer


### PR DESCRIPTION
Commit cac33be introduced a great benchmark to compare different
implementations for `Base62.compatible?`.

I noticed two things:

1. We ran `Enumerable.include?` over a slightly long String, so I thought
converting it to a Set would help - and it does! It's over 3x faster
than the previously fastest method. Please see the benchmark results below.
2. It seems that the chosen implementation differs from the actual
benchmark. I added the code used in `Base62.compatible?` to the
benchmark and it actually seems the slowest of all.

```
Warming up --------------------------------------
            include?    18.811k i/100ms
  include? optimized   113.581k i/100ms
       Regexp#match?    35.244k i/100ms
Regexp#match? - commit cac33be
                         2.932k i/100ms
             Array#-    14.629k i/100ms
          two finger     5.644k i/100ms
Calculating -------------------------------------
            include?    183.872k (± 2.8%) i/s -    921.739k in   5.016951s
  include? optimized      1.088M (± 6.1%) i/s -      5.452M in   5.035707s
       Regexp#match?    339.933k (± 6.7%) i/s -      1.692M in   5.004362s
Regexp#match? - commit cac33be
                         29.828k (± 2.1%) i/s -    149.532k in   5.015367s
             Array#-    139.578k (± 8.6%) i/s -    702.192k in   5.086914s
          two finger     55.528k (± 2.4%) i/s -    282.200k in   5.085177s

Comparison:
  include? optimized:  1087870.6 i/s
       Regexp#match?:   339933.4 i/s - 3.20x  (± 0.00) slower
            include?:   183871.7 i/s - 5.92x  (± 0.00) slower
             Array#-:   139578.3 i/s - 7.79x  (± 0.00) slower
          two finger:    55527.9 i/s - 19.59x  (± 0.00) slower
          Regexp#match? - commit cac33be:    29828.4 i/s - 36.47x  (± 0.00) slower
```