### PR TITLE
Make KSUID::Type obey value object semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- `KSUID::Type` acts as a proper value object now, which means that you may use it as a Hash key or use it in ActiveRecord's `.includes`. `KSUID::Type#eql?`, `KSUID::Type#hash`, and `KSUID::Type#==` now work as expected. Note that `KSUID::Type#==` is more lax than `KSUID::Type#eql?` because it can also match any object that converts to a string matching its value. This means that you can use it to match against `String` KSUIDs.
+
 ## [0.3.0](https://github.com/michaelherold/ksuid/compare/v0.2.0...v0.3.0) - 2021-10-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 
 - `ActiveRecord::QueryMethods#include` works as expected now due to the fix on the value object semantics of `KSUID::Type`.
+- Binary KSUID primary and foreign keys work as expected on JRuby.
 
 ## [0.3.0](https://github.com/michaelherold/ksuid/compare/v0.2.0...v0.3.0) - 2021-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - `KSUID::Type` acts as a proper value object now, which means that you may use it as a Hash key or use it in ActiveRecord's `.includes`. `KSUID::Type#eql?`, `KSUID::Type#hash`, and `KSUID::Type#==` now work as expected. Note that `KSUID::Type#==` is more lax than `KSUID::Type#eql?` because it can also match any object that converts to a string matching its value. This means that you can use it to match against `String` KSUIDs.
 
+### Fixed
+
+- `ActiveRecord::QueryMethods#include` works as expected now due to the fix on the value object semantics of `KSUID::Type`.
+
 ## [0.3.0](https://github.com/michaelherold/ksuid/compare/v0.2.0...v0.3.0) - 2021-10-07
 
 ### Added

--- a/lib/ksuid/activerecord/binary_type.rb
+++ b/lib/ksuid/activerecord/binary_type.rb
@@ -51,14 +51,6 @@ module KSUID
 
         super(KSUID.call(value).to_bytes)
       end
-
-      # The identifier to use within ActiveRecord's type registry
-      #
-      # @api private
-      # @return [Symbol]
-      def type
-        :ksuid_binary
-      end
     end
   end
 end

--- a/lib/ksuid/activerecord/type.rb
+++ b/lib/ksuid/activerecord/type.rb
@@ -50,14 +50,6 @@ module KSUID
 
         KSUID.call(value).to_s
       end
-
-      # The identifier to use within ActiveRecord's type registry
-      #
-      # @api private
-      # @return [Symbol]
-      def type
-        :ksuid
-      end
     end
   end
 end

--- a/lib/ksuid/type.rb
+++ b/lib/ksuid/type.rb
@@ -63,6 +63,36 @@ module KSUID
       other.to_s == to_s
     end
 
+    # Checks whether this KSUID hashes to the same hash key as another
+    #
+    # @api semipublic
+    #
+    # @example Checks whether two KSUIDs hash to the same key
+    #   KSUID.new.eql? KSUID.new
+    #
+    # @param other [KSUID::Type] the other KSUID to check against
+    # @return [Boolean]
+    def eql?(other)
+      hash == other.hash
+    end
+
+    # Generates the key to use when using a KSUID as a hash key
+    #
+    # @api semipublic
+    #
+    # @example Using a KSUID as a Hash key
+    #   ksuid1 = KSUID.new
+    #   ksuid2 = KSUID.from_base62(ksuid1.to_s)
+    #   values_by_ksuid = {}
+    #
+    #   values_by_ksuid[ksuid1] = "example"
+    #   values_by_ksuid[ksuid2] #=> "example"
+    #
+    # @return [Integer]
+    def hash
+      @uid.hash
+    end
+
     # Prints the KSUID for debugging within a console
     #
     # @api public

--- a/spec/ksuid_spec.rb
+++ b/spec/ksuid_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe KSUID do
     KSUID.configure { |config| config.random_generator = generator }
 
     expect(KSUID.config.random_generator).to eq(generator)
+  ensure
+    KSUID.configure { |config| config.random_generator = KSUID::Configuration.default_generator }
   end
 
   describe '.call' do

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -1,6 +1,23 @@
 # frozen_string_literal: true
 
 RSpec.describe KSUID::Type do
+  describe 'value object semantics' do
+    it 'uses value comparison instead of identity comparison' do
+      ksuid1 = KSUID.new(time: Time.now)
+      ksuid2 = KSUID.from_base62(ksuid1.to_s)
+      hash = {}
+
+      hash[ksuid1] = 'Hello, world'
+
+      aggregate_failures do
+        expect(ksuid1).to eq ksuid2
+        expect(ksuid1).to eql ksuid2
+        expect(ksuid1).not_to equal ksuid2
+        expect(hash[ksuid2]).to eq 'Hello, world'
+      end
+    end
+  end
+
   describe '.from_base62' do
     it 'converts a base62 KSUID properly' do
       ksuid = KSUID.from_base62(KSUID::MAX_STRING_ENCODED)
@@ -17,6 +34,18 @@ RSpec.describe KSUID::Type do
       array = [ksuid2, ksuid1].sort
 
       expect(array).to eq([ksuid1, ksuid2])
+    end
+  end
+
+  describe '#==' do
+    it 'matches against other KSUID::Types as well as String' do
+      ksuid1 = KSUID.new(time: Time.now)
+      ksuid2 = KSUID.from_base62(ksuid1.to_s)
+
+      aggregate_failures do
+        expect(ksuid1).to eq ksuid2
+        expect(ksuid1).to eq ksuid2.to_s
+      end
     end
   end
 


### PR DESCRIPTION
In order for KSUIDs to be useful as hash keys and to work with `ActiveRecord::QueryMethods#includes`, they must obey value object semantics. That is, they must:

1. `#==` each other
2. `#eql?` each other and have the same `#hash`
3. Not `#equal?` each other unless they are the same object

This change implements (2) to ensure that they work in these situations.

Additionally, this change includes two fixes for handling KSUID keys in ActiveRecord to make sure that preloading and, on JRuby, even just plain loading of associations with KSUID primary keys.

Closes #26