### PR TITLE
Update Ruby and Rails version support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous integration
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
       - "*"
@@ -14,25 +14,21 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - "2.5"
-          - "2.6"
           - "2.7"
-          - jruby-9.2.13.0
+          - "3.0"
+          - "3.1"
+          - jruby-9.3
         rails:
-          - "5.0"
-          - "5.1"
-          - "5.2"
           - "6.0"
           - "6.1"
+          - "7.0"
         exclude:
-          - ruby: "2.7"
-            rails: "5.0"
-          - ruby: "2.7"
-            rails: "5.1"
-          - ruby: "2.7"
-            rails: "5.2"
-          - ruby: "jruby-9.2.13.0"
-            rails: "6.1"
+          - ruby: "3.0"
+            rails: "6.0"
+          - ruby: "3.1"
+            rails: "6.0"
+          - ruby: jruby-9.3
+            rails: "7.0"
     name: Test Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:
       - uses: actions/checkout@v2

--- a/Appraisals
+++ b/Appraisals
@@ -1,34 +1,20 @@
 # frozen-string-literal: true
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.7.0')
-  appraise 'rails-5.0' do
-    gem 'activerecord-jdbcsqlite3-adapter', '~> 50', platforms: %i[jruby]
-    gem 'rails', '~> 5.0.0'
-    gem 'sqlite3', '~> 1.3.6', platforms: %i[mri mingw x64_mingw]
-  end
-
-  appraise 'rails-5.1' do
-    gem 'activerecord-jdbcsqlite3-adapter', '~> 51', platforms: %i[jruby]
-    gem 'rails', '~> 5.1.0'
-    gem 'sqlite3', '~> 1.3', '>= 1.3.6', platforms: %i[mri mingw x64_mingw]
-  end
-
-  appraise 'rails-5.2' do
-    gem 'activerecord-jdbcsqlite3-adapter', '~> 52', platforms: %i[jruby]
-    gem 'rails', '~> 5.2.0'
-    gem 'sqlite3', '~> 1.3', '>= 1.3.6', platforms: %i[mri mingw x64_mingw]
-  end
-end
-
 appraise 'rails-6.0' do
   gem 'activerecord-jdbcsqlite3-adapter', '~> 60', platforms: %i[jruby]
   gem 'rails', '~> 6.0.0'
   gem 'sqlite3', '~> 1.4', platforms: %i[mri mingw x64_mingw]
 end
 
+appraise 'rails-6.1' do
+  gem 'activerecord-jdbcsqlite3-adapter', '~> 61', platforms: %i[jruby]
+  gem 'rails', '~> 6.1.0'
+  gem 'sqlite3', '~> 1.4', platforms: %i[mri mingw x64_mingw]
+end
+
 unless RUBY_ENGINE == 'jruby'
-  appraise 'rails-6.1' do
-    gem 'rails', '~> 6.1.0.rc1'
+  appraise 'rails-7.0' do
+    gem 'rails', '~> 7.0.0'
     gem 'sqlite3', '~> 1.4', platforms: %i[mri mingw x64_mingw]
   end
 end

--- a/README.md
+++ b/README.md
@@ -217,10 +217,10 @@ So you’re interested in contributing to KSUID? Check out our [contributing gui
 
 This library aims to support and is [tested against][actions] the following Ruby versions:
 
-* Ruby 2.5
-* Ruby 2.6
 * Ruby 2.7
-* JRuby 9.2
+* Ruby 3.0
+* Ruby 3.1
+* JRuby 9.3
 
 If something doesn't work on one of these versions, it's a bug.
 

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -2,8 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "activerecord-jdbcsqlite3-adapter", "~> 61", platforms: [:jruby]
-gem "rails", "~> 6.1.0"
+gem "rails", "~> 7.0.0"
 gem "sqlite3", "~> 1.4", platforms: [:mri, :mingw, :x64_mingw]
 
 group :development do

--- a/lib/ksuid/activerecord/binary_type.rb
+++ b/lib/ksuid/activerecord/binary_type.rb
@@ -7,12 +7,12 @@ module KSUID
     # @api private
     #
     # @example Set an attribute as a KSUID using the verbose syntax
-    #   class Event < ActiveRecord::Base
+    #   class EventWithBareBinaryType < ActiveRecord::Base
     #     attribute :ksuid, KSUID::ActiveRecord::BinaryType.new, default: -> { KSUID.new }
     #   end
     #
     # @example Set an attribute as a KSUID using the pre-registered type
-    #   class Event < ActiveRecord::Base
+    #   class EventWithRegisteredBinaryType < ActiveRecord::Base
     #     attribute :ksuid, :ksuid_binary, default: -> { KSUID.new }
     #   end
     class BinaryType < ::ActiveRecord::Type::Binary

--- a/lib/ksuid/activerecord/type.rb
+++ b/lib/ksuid/activerecord/type.rb
@@ -7,12 +7,12 @@ module KSUID
     # @api private
     #
     # @example Set an attribute as a KSUID using the verbose syntax
-    #   class Event < ActiveRecord::Base
+    #   class EventWithBareType < ActiveRecord::Base
     #     attribute :ksuid, KSUID::ActiveRecord::Type.new, default: -> { KSUID.new }
     #   end
     #
     # @example Set an attribute as a KSUID using the pre-registered type
-    #   class Event < ActiveRecord::Base
+    #   class EventWithRegisteredType < ActiveRecord::Base
     #     attribute :ksuid, :ksuid, default: -> { KSUID.new }
     #   end
     class Type < ::ActiveRecord::Type::String

--- a/spec/doctest_helper.rb
+++ b/spec/doctest_helper.rb
@@ -4,7 +4,8 @@ require 'rails'
 require 'active_record'
 require 'ksuid'
 require 'ksuid/activerecord'
+require 'ksuid/activerecord/table_definition'
 
-YARD::Doctest.configure do |doctest|
-  doctest.skip 'KSUID::ActiveRecord::TableDefinition'
-end
+ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: ':memory:')
+ActiveRecord::Base.logger = Logger.new(IO::NULL)
+ActiveRecord::Schema.verbose = false


### PR DESCRIPTION
This constrains support to currently supported Rubies. I know that JRuby 9.2 is still supported, but it targets Ruby 2.5 semantics, which is out-of-date. Since versions prior to v0.4.0 had broken ActiveRecord support on JRuby, I wonder if it's worth having in CI. I like to be inclusive though, so I'm keeping JRuby 9.3.

It also constrains support to currently supported versions of Rails. In order to do that, it updates the doctest setup.