### PR TITLE
Speed up the Base62.compatible? check by 10x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /spec/examples.txt
 /spec/reports/
 /tmp/
+*.jsonld
 Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - `KSUID::ActiveRecord` is now `ActiveRecord::KSUID`. The original constant will continue to work until v1.0.0, but will emit a warning upon boot of your application. To silence the deprecation, change all uses of `KSUID::ActiveRecord` to the new constant, `ActiveRecord::KSUID`. See the [upgrading notice][./UPGRADING.md] for more information.
 
+### Miscellaneous
+
+- The compatibility check for the Base62 implementation in the gem is about 10x faster now. The original optimization did not optimize as much due to an error with the benchmark. This change has a tested benchmark that shows a great improvement. Note that this is a micro-optimization and we see no real performance gain in the parsing of KSUID strings.
+
 ## [0.4.0](https://github.com/michaelherold/ksuid/compare/v0.3.0...v0.4.0) - 2022-07-29
 
 ### Added

--- a/benchmark/changes.rb
+++ b/benchmark/changes.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# A benchmark that tests the performance of changes in the library
+#
+# It uses the "hold" system of benchmark-ips, which means that you
+# run it once as a baseline, make changes, then run it again to compare
+
+$LOAD_PATH.unshift File.expand_path(__dir__, "../lib")
+
+require 'benchmark/ips'
+require 'ksuid'
+
+EXAMPLE = '15Ew2nYeRDscBipuJicYjl970D1'
+BINARY_EXAMPLE = ("\xFF" * 20).b
+
+Benchmark.ips do |bench|
+  bench.report('baseline') { KSUID::Base62.compatible?(EXAMPLE) }
+  bench.report('experiment') { KSUID::Base62.compatible?(EXAMPLE) }
+
+  bench.hold!('changes.jsonld')
+  bench.compare!
+end

--- a/benchmark/charset_inclusion.rb
+++ b/benchmark/charset_inclusion.rb
@@ -4,11 +4,34 @@
 # only characters from the KSUID Base62 charset.
 
 require 'benchmark/ips'
+require 'set'
 
 EXAMPLE = '15Ew2nYeRDscBipuJicYjl970D1'
+BAD_EXAMPLE = '15Ew2nYeRDscBipuJicYjl970D!'
 CHARSET = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'
 MATCHER = /[^#{CHARSET}]/
 CHARS   = CHARSET.chars
+SET     = Set.new(CHARS)
+
+# Checks each char individually against the charset
+def include?(example)
+  example.each_char.all? { |c| CHARSET.include?(c) }
+end
+
+# Checks for a match against anything not in the charset
+def regexp_match?(example)
+  !MATCHER.match?(example)
+end
+
+# Checks each character against the regexp
+def match_by_char?(example)
+  example.each_char.all? { |c| !MATCHER.match?(c) }
+end
+
+# Splits the string and uses array difference to check for stray characters
+def split_diff(example)
+  (example.split('') - CHARS).empty?
+end
 
 # Uses a two-finger method to check each character against each charset member
 # exactly once
@@ -28,11 +51,46 @@ def two_finger(example)
     example[left - 1] == CHARSET[right]
 end
 
+def set_include?(example)
+  example.each_char.all? { |c| SET.include?(c) }
+end
+
+include?(EXAMPLE) or raise "include? does not work"
+regexp_match?(EXAMPLE) or raise "regexp_match? does not work"
+match_by_char?(EXAMPLE) or raise "match_by_char? does not work"
+split_diff(EXAMPLE) or raise "split_diff does not work"
+two_finger(EXAMPLE) or raise "two_finger does not work"
+set_include?(EXAMPLE) or raise "set_include? does not work"
+
+include?(BAD_EXAMPLE) and raise "include? does not work"
+regexp_match?(BAD_EXAMPLE) and raise "regexp_match? does not work"
+match_by_char?(BAD_EXAMPLE) and raise "match_by_char? does not work"
+split_diff(BAD_EXAMPLE) and raise "split_diff does not work"
+two_finger(BAD_EXAMPLE) and raise "two_finger does not work"
+set_include?(BAD_EXAMPLE) and raise "set_include? does not work"
+
+puts "Benchmarking good example\n\n"
+
 Benchmark.ips do |bench|
-  bench.report('include?') { EXAMPLE.each_char.all? { |c| CHARSET.include? c } }
-  bench.report('Regexp#match?') { !CHARSET.match?(EXAMPLE) }
-  bench.report('Array#-') { EXAMPLE.split('') - CHARS }
+  bench.report('include?') { include?(EXAMPLE) }
+  bench.report('Regexp#match?') { regexp_match?(EXAMPLE) }
+  bench.report('#match?(char)') { match_by_char?(EXAMPLE) }
+  bench.report('Array#-') { split_diff(EXAMPLE) }
   bench.report('two finger') { two_finger(EXAMPLE) }
+  bench.report('Set#include?') { set_include?(EXAMPLE) }
+
+  bench.compare!
+end
+
+puts "Benchmarking bad example\n\n"
+
+Benchmark.ips do |bench|
+  bench.report('include?') { include?(BAD_EXAMPLE) }
+  bench.report('Regexp#match?') { regexp_match?(BAD_EXAMPLE) }
+  bench.report('#match?(char)') { match_by_char?(BAD_EXAMPLE) }
+  bench.report('Array#-') { split_diff(BAD_EXAMPLE) }
+  bench.report('two finger') { two_finger(BAD_EXAMPLE) }
+  bench.report('Set#include?') { set_include?(BAD_EXAMPLE) }
 
   bench.compare!
 end

--- a/lib/ksuid/base62.rb
+++ b/lib/ksuid/base62.rb
@@ -35,7 +35,7 @@ module KSUID
     # @param string [String] the string to check for compatibility
     # @return [Boolean]
     def self.compatible?(string)
-      string.each_char.all? { |char| !MATCHER.match?(char) }
+      !MATCHER.match?(string)
     end
 
     # Decodes a base 62-encoded string into an integer

--- a/spec/base62_spec.rb
+++ b/spec/base62_spec.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 RSpec.describe KSUID::Base62 do
+  describe '#compatible?' do
+    it 'correctly detects invalid values in a string' do
+      expect(KSUID::Base62.compatible?('15Ew2nYeRDscBipuJicYjl970D1')).to be true
+      expect(KSUID::Base62.compatible?(("\xFF" * 20).b)).not_to be true
+    end
+  end
+
   describe '#decode' do
     it 'decodes base 62 numbers that may or may not be zero-padded' do
       %w[awesomesauce 00000000awesomesauce].each do |encoded|


### PR DESCRIPTION
This change _actually_ applies the optimization I intended to in 2021.

<details>
<summary>Results of benchmark</summary>

```
Warming up --------------------------------------
            include?    22.058k i/100ms
       Regexp#match?   221.543k i/100ms
       #match?(char)    18.529k i/100ms
             Array#-    16.771k i/100ms
          two finger     6.942k i/100ms
        Set#include?    19.925k i/100ms
Calculating -------------------------------------
            include?    218.982k (± 1.9%) i/s -      1.103M in   5.038327s
       Regexp#match?      2.192M (± 2.2%) i/s -     11.077M in   5.056699s
       #match?(char)    184.918k (± 2.0%) i/s -    926.450k in   5.012209s
             Array#-    180.118k (± 1.6%) i/s -    905.634k in   5.029231s
          two finger     68.919k (± 1.4%) i/s -    347.100k in   5.037446s
        Set#include?    198.218k (± 1.6%) i/s -    996.250k in   5.027401s

Comparison:
       Regexp#match?:  2191627.2 i/s
            include?:   218981.8 i/s - 10.01x  (± 0.00) slower
        Set#include?:   198218.3 i/s - 11.06x  (± 0.00) slower
       #match?(char):   184918.5 i/s - 11.85x  (± 0.00) slower
             Array#-:   180118.1 i/s - 12.17x  (± 0.00) slower
          two finger:    68918.5 i/s - 31.80x  (± 0.00) slower
```

</details>

Unfortunately, it turns out that this isn't a hot path and leads to no performance gain. It's still useful to have though.

Relates to #23
Closes #27