### PR TITLE
Add a `KSUID.string` string builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## 0.5.0 - Unreleased
 
+### Added
+
+- If you'd rather deal in KSUID strings instead of `KSUID::Type`s, you can now generate them simply with `KSUID.string`. It takes the same arguments, `payload` and `time` as `KSUID.new`, but returns a string instead of a `KSUID::Type`.
+
 ### Deprecated
 
 - `KSUID::ActiveRecord` is now `ActiveRecord::KSUID`. The original constant will continue to work until v1.0.0, but will emit a warning upon boot of your application. To silence the deprecation, change all uses of `KSUID::ActiveRecord` to the new constant, `ActiveRecord::KSUID`. See the [upgrading notice][./UPGRADING.md] for more information.

--- a/lib/ksuid.rb
+++ b/lib/ksuid.rb
@@ -176,6 +176,7 @@ module KSUID
   # Instantiates a new KSUID
   #
   # @api public
+  # @since 0.5.0
   #
   # @example Generate a new KSUID for the current second
   #   KSUID.new
@@ -188,6 +189,23 @@ module KSUID
   # @return [KSUID::Type] the generated KSUID
   def self.new(payload: nil, time: Time.now)
     Type.new(payload: payload, time: time)
+  end
+
+  # Generates a KSUID string
+  #
+  # @api public
+  #
+  # @example Generate a new KSUID string for the current second
+  #   KSUID.string
+  #
+  # @example Generate a new KSUID string for a given timestamp
+  #   KSUID.string(time: Time.parse('2017-11-05 15:00:04 UTC'))
+  #
+  # @param payload [String, Array<Integer>, nil] the payload for the KSUID string
+  # @param time [Time] the timestamp to use for the KSUID string
+  # @return [String] the generated string
+  def self.string(payload: nil, time: Time.now)
+    Type.new(payload: payload, time: time).to_s
   end
 
   # Casts a string into a KSUID

--- a/spec/ksuid_spec.rb
+++ b/spec/ksuid_spec.rb
@@ -58,4 +58,21 @@ RSpec.describe KSUID do
       expect { KSUID.call(1) }.to raise_error(ArgumentError)
     end
   end
+
+  describe '.string' do
+    it 'uses the current time and a random payload by default' do
+      string = KSUID.string
+
+      expect(string.length).to eq 27
+    end
+
+    it 'accepts a payload and a time' do
+      string = KSUID.string(
+        payload: ("\xFF" * KSUID::BYTES[:payload]),
+        time: Time.new(2150, 6, 19, 23, 21, 35, 'UTC')
+      )
+
+      expect(string).to eq KSUID::MAX_STRING_ENCODED
+    end
+  end
 end


### PR DESCRIPTION
In some cases, it makes sense to deal with KSUID strings instead of `KSUID::Type` objects. For those cases, this string builder method helps by reducing the boilerplate of:

    String(KSUID.new)  # or
    KSUID.new.to_s

to:

    KSUID.string

Closes #28