### PR TITLE
Add support for prefixed KSUIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 
 - If you'd rather deal in KSUID strings instead of `KSUID::Type`s, you can now generate them simply with `KSUID.string`. It takes the same arguments, `payload` and `time` as `KSUID.new`, but returns a string instead of a `KSUID::Type`.
+- `KSUID.prefixed` and the `KSUID::Prefixed` class now can generate prefixed KSUIDs to make them visually identifiable for their source. You cannot prefix a binary-encoded KSUID, only base 62-encoded ones.
+- `ActiveRecord::KSUID` now accepts a `prefix:` argument for handling prefixed KSUIDs. In addition, the `ksuid` column type also accepts a `prefix:` argument to calculate the intended size of the column with the prefix.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,28 @@ KSUID.configure do |config|
 end
 ```
 
+### Prefixed KSUIDs
+
+If you use KSUIDs in multiple contexts, you can prefix them to make them easily identifiable.
+
+```ruby
+ksuid = KSUID.prefixed('evt_')
+```
+
+Just like a normal KSUID, you can use a specific timestamp:
+
+``` ruby
+ksuid = KSUID.prefixed('evt_', time: time)  # where time is a Time-like object
+```
+
+You can also parse a prefixed KSUID from a string that you received:
+
+```ruby
+ksuid = KSUID::Prefixed.from_base62(base62_string, prefix: 'evt_')
+```
+
+Prefixed KSUIDs order themselves with non-prefixed KSUIDs as if their prefix did not exist. With other prefixed KSUIDs, they order first by their prefix, then their timestamp.
+
 ### ActiveRecord
 
 Whether you are using ActiveRecord inside an existing project or in a new project, usage is simple. Additionally, you can use it with or without Rails.
@@ -198,6 +220,28 @@ class Event < ApplicationRecord
   include ActiveRecord::KSUID[:my_field_name, binary: true]
 end
 ```
+
+#### Using a prefix on your KSUID field
+
+For prefixed KSUIDs in ActiveRecord, you must pass the intended prefix during table definition so that the field is of appropriate size.
+
+```ruby
+class CreateEvents < ActiveRecord::Migration[5.2]
+  create_table :events do |table|
+    table.ksuid :ksuid, prefix: 'evt_'
+  end
+end
+```
+
+You also must pass it in the module builder that you include in your model:
+
+```ruby
+class Event < ApplicationRecord
+  include ActiveRecord::KSUID[:ksuid, prefix: 'evt_']
+end
+```
+
+You cannot use a prefix with a binary-encoded KSUID.
 
 #### Use the KSUID as your `created_at` timestamp
 

--- a/lib/active_record/ksuid/prefixed_type.rb
+++ b/lib/active_record/ksuid/prefixed_type.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module ActiveRecord
+  module KSUID
+    # A string-serialized, prefixed KSUID for storage within an ActiveRecord database
+    #
+    # @api private
+    # @since 0.5.0
+    #
+    # @example Set an attribute as a prefixed KSUID using the verbose syntax
+    #   class EventWithBarePrefixedType < ActiveRecord::Base
+    #     attribute(
+    #       :ksuid,
+    #       ActiveRecord::KSUID::PrefixedType.new(prefix: 'evt_'),
+    #       default: -> { KSUID.prefixed('evt_') }
+    #     )
+    #   end
+    #
+    # @example Set an attribute as a prefixed KSUID using the pre-registered type
+    #   class EventWithRegisteredPrefixedType < ActiveRecord::Base
+    #     attribute :ksuid, :ksuid_prefixed, prefix: 'evt_', default: -> { KSUID.prefixed('evt_') }
+    #   end
+    class PrefixedType < ::ActiveRecord::Type::String
+      # Instantiates an ActiveRecord::Type for handling prefixed KSUIDs
+      #
+      # @param prefix [String] the prefix to add to the KSUID
+      def initialize(prefix: '')
+        @prefix = prefix
+        super()
+      end
+
+      # Casts a value from user input into a {KSUID::Prefixed}
+      #
+      # Type casting happens via the attribute setter and can take input from
+      # many places, including:
+      #
+      #   1. The Rails form builder
+      #   2. Directly from the attribute setter
+      #   3. From the model initializer
+      #
+      # @param value [String, Array<Integer>, KSUID::Prefixed] the value to cast into a KSUID
+      # @return [KSUID::Prefixed] the type-casted value
+      def cast(value)
+        ::KSUID::Prefixed.call(value, prefix: @prefix)
+      end
+
+      # Converts a value from database input to a {KSUID::Prefixed}
+      #
+      # @param value [String, nil] the database-serialized, prefixed KSUID to convert
+      # @return [KSUID::Prefixed] the deserialized, prefixed KSUID
+      def deserialize(value)
+        return unless value
+
+        ::KSUID::Prefixed.from_base62(value, prefix: @prefix)
+      end
+
+      # Casts the value from a KSUID into a database-understandable format
+      #
+      # @param value [KSUID::Prefixed, nil] the prefixed KSUID in Ruby format
+      # @return [String, nil] the base 62-encoded, prefixed KSUID for storage in the database
+      def serialize(value)
+        return unless value
+
+        ::KSUID::Prefixed.call(value, prefix: @prefix).to_s
+      end
+    end
+  end
+end
+
+ActiveRecord::Type.register(:ksuid_prefixed, ActiveRecord::KSUID::PrefixedType)

--- a/lib/active_record/ksuid/table_definition.rb
+++ b/lib/active_record/ksuid/table_definition.rb
@@ -22,9 +22,12 @@ module ActiveRecord
       #
       # @param args [Array<Symbol>] the list of fields to define as KSUIDs
       # @param options [Hash] see {ActiveRecord::ConnectionAdapters::TableDefinition}
+      # @option options [String] :prefix the prefix expected in front of the KSUID
       # @return [void]
       def ksuid(*args, **options)
-        args.each { |name| column(name, :string, **options.merge(limit: 27)) }
+        prefix_length = options.delete(:prefix)&.length || 0
+
+        args.each { |name| column(name, :string, **options.merge(limit: 27 + prefix_length)) }
       end
 
       # Defines a field as a binary-based KSUID

--- a/lib/ksuid.rb
+++ b/lib/ksuid.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'ksuid/configuration'
-require_relative 'ksuid/type'
 require_relative 'ksuid/version'
 
 # The K-Sortable Unique IDentifier (KSUID)
@@ -63,7 +62,7 @@ module KSUID
   # The number of bytes that are used to represent each part of a KSUID
   #
   # @return [Hash{Symbol => Integer}] the map of data type to number of bytes
-  BYTES = { payload: 16, timestamp: 4, total: 20 }.freeze
+  BYTES = { base62: 27, payload: 16, timestamp: 4, total: 20 }.freeze
 
   # The number of characters in a base 62-encoded KSUID
   #
@@ -74,6 +73,11 @@ module KSUID
   #
   # @return [String]
   MAX_STRING_ENCODED = 'aWgEPTl1tmebfsQzFP4bxwgy80V'
+
+  autoload :Base62, 'ksuid/base62'
+  autoload :Prefixed, 'ksuid/prefixed'
+  autoload :Type, 'ksuid/type'
+  autoload :Utils, 'ksuid/utils'
 
   # Converts a KSUID-compatible value into an actual KSUID
   #
@@ -89,6 +93,7 @@ module KSUID
     return unless ksuid
 
     case ksuid
+    when KSUID::Prefixed then ksuid.to_ksuid
     when KSUID::Type then ksuid
     when Array then KSUID.from_bytes(ksuid)
     when String then cast_string(ksuid)
@@ -189,6 +194,25 @@ module KSUID
   # @return [KSUID::Type] the generated KSUID
   def self.new(payload: nil, time: Time.now)
     Type.new(payload: payload, time: time)
+  end
+
+  # Instantiates a new {KSUID::Prefixed}
+  #
+  # @api public
+  # @since 0.5.0
+  #
+  # @example Generate a new prefixed KSUID for the current second
+  #   KSUID.prefixed('evt_')
+  #
+  # @example Generate a new prefixed KSUID for a given timestamp
+  #   KSUID.prefixed('cus_', time: Time.parse('2022-08-16 10:36:00 UTC'))
+  #
+  # @param prefix [String] the prefix to apply to the KSUID
+  # @param payload [String, Array<Integer>, nil] the payload for the KSUID
+  # @param time [Time] the timestamp to use for the KSUID
+  # @return [KSUID::Prefixed] the generated, prefixed KSUID
+  def self.prefixed(prefix, payload: nil, time: Time.now)
+    Prefixed.new(prefix, payload: payload, time: time)
   end
 
   # Generates a KSUID string

--- a/lib/ksuid/prefixed.rb
+++ b/lib/ksuid/prefixed.rb
@@ -1,0 +1,242 @@
+# frozen_string_literal: true
+
+module KSUID
+  # Encapsulates the data type for a prefixed KSUID
+  #
+  # When you have different types of KSUIDs in your application, it can be
+  # helpful to add an identifier to the front of them to give you an idea for
+  # what kind of object the KSUID belongs to.
+  #
+  # For example, you might use KSUIDs to identify both Events and Customers. For
+  # an Event, you could prefix the KSUID with the string `evt_`. Likewise, for
+  # Customers, you could prefix them with the string `cus_`.
+  #
+  # {KSUID::Prefixed} gives you affordances for doing just this.
+  #
+  # ## Ordering
+  #
+  # {KSUID::Prefixed}s are partially orderable with {KSUID::Type} by their
+  # timestamps. When ordering them with other {KSUID::Prefixed} instances, they
+  # order first by prefix, then by timestamp. This means that in a mixed
+  # collection, all Customer KSUIDs (prefix: `cus_`) would be grouped before all
+  # Event KSUIDs (prefix `evt_`).
+  #
+  # ## Interface
+  #
+  # You typically will not instantiate this class directly, but instead use the
+  # {KSUID.prefixed} builder method to save some typing.
+  #
+  # The most commonly used helper methods for the {KSUID} module also exist on
+  # {KSUID::Prefixed} for converting between different forms of output.
+  #
+  # ## Differences from {KSUID::Type}
+  #
+  # One other thing to note is that {KSUID::Prefixed} is not intended to handle
+  # binary data because the prefix does not make sense in either the byte string
+  # or packed array formats.
+  #
+  # @since 0.5.0
+  class Prefixed < Type
+    include Comparable
+
+    # Converts a KSUID-compatible value into a {KSUID::Prefixed}
+    #
+    # @api public
+    #
+    # @example Converts a base 62 KSUID string into a {KSUID::Prefixed}
+    #   KSUID::Prefixed.call('15Ew2nYeRDscBipuJicYjl970D1', prefix: 'evt_')
+    #
+    # @param ksuid [String, KSUID::Prefixed, KSUID::Type] the prefixed KSUID-compatible value
+    # @return [KSUID::Prefixed] the converted, prefixed KSUID
+    # @raise [ArgumentError] if the value is not prefixed KSUID-compatible
+    def self.call(ksuid, prefix:)
+      return unless ksuid && prefix
+
+      case ksuid
+      when KSUID::Prefixed then from_base62(ksuid.to_ksuid.to_s, prefix: prefix)
+      when KSUID::Type then from_base62(ksuid.to_s, prefix: prefix)
+      when String then cast_string(ksuid, prefix: prefix)
+      else
+        raise ArgumentError, "Cannot convert #{ksuid.inspect} to KSUID::Prefixed"
+      end
+    end
+
+    # Converts a base 62-encoded string into a {KSUID::Prefixed}
+    #
+    # @api public
+    #
+    # @example Parse a KSUID string into a prefixed object
+    #   KSUID::Prefixed.from_base62('0vdbMgWkU6slGpLVCqEFwkkZvuW', prefix: 'evt_')
+    #
+    # @param string [String] the base 62-encoded KSUID to convert into an object
+    # @param prefix [String] the prefix to add to the KSUID
+    # @return [KSUID::Prefixed] the prefixed KSUID generated from the string
+    def self.from_base62(string, prefix:)
+      string = string.sub(/\A#{prefix}/, '')
+      int = Base62.decode(string)
+      bytes = Utils.int_to_bytes(int, 160)
+
+      from_bytes(bytes, prefix: prefix)
+    end
+
+    # Casts a string into a {KSUID::Prefixed}
+    #
+    # @api private
+    #
+    # @param ksuid [String] the string to convert into a {KSUID::Prefixed}
+    # @param prefix [String] the prefix to prepend to the KSUID
+    # @return [KSUID::Prefixed] the converted, prefixed KSUID
+    def self.cast_string(ksuid, prefix:)
+      ksuid = ksuid[-KSUID::BYTES[:base62]..-1] if ksuid.length >= KSUID::BYTES[:base62]
+
+      unless Base62.compatible?(ksuid)
+        raise ArgumentError, 'Prefixed KSUIDs cannot be binary strings'
+      end
+
+      from_base62(ksuid, prefix: prefix)
+    end
+    private_class_method :cast_string
+
+    # Converts a byte string or byte array into a KSUID
+    #
+    # @api private
+    #
+    # @param bytes [String] the byte string to convert into an object
+    # @return [KSUID::Prefixed] the prefixed KSUID generated from the bytes
+    def self.from_bytes(bytes, prefix:)
+      bytes = bytes.bytes
+      timestamp = Utils.int_from_bytes(bytes.first(KSUID::BYTES[:timestamp]))
+      payload = Utils.byte_string_from_array(bytes.last(KSUID::BYTES[:payload]))
+
+      new(prefix, payload: payload, time: Time.at(timestamp + EPOCH_TIME))
+    end
+    private_class_method :from_bytes
+
+    # Instantiates a new {KSUID::Prefixed}
+    #
+    # @api semipublic
+    #
+    # @example Generate a new {KSUID::Prefixed} for the current second
+    #   KSUID::Prefixed.new('evt_')
+    #
+    # @example Generate a new {KSUID::Prefixed} for a given timestamp
+    #   KSUID::Prefixed.new('cus_', time: Time.parse('2017-11-05 15:00:04 UTC'))
+    #
+    # @param prefix [String] the prefix to add to the KSUID
+    # @param payload [String, Array<Integer>, nil] the payload for the KSUID
+    # @param time [Time] the timestamp to use for the KSUID
+    # @return [KSUID::Prefix] the generated, prefixed KSUID
+    def initialize(prefix, payload: nil, time: Time.now)
+      raise ArgumentError, 'requires a prefix' unless prefix
+
+      super(payload: payload, time: time)
+
+      @prefix = prefix
+    end
+
+    # The prefix in front of the KSUID
+    #
+    # @api semipublic
+    #
+    # @example Getting the prefix to create a similar {KSUID::Prefixed}
+    #   ksuid1 = KSUID.prefixed('cus_')
+    #   ksuid2 = KSUID.prefixed(ksuid1.prefix)
+    #
+    # @return [String] the prefix of the {KSUID::Prefixed}
+    attr_reader :prefix
+
+    # Implements the Comparable interface for sorting {KSUID::Prefixed}s
+    #
+    # @api private
+    #
+    # @param other [KSUID::Type] the other object to compare against
+    # @return [Integer, nil] nil for uncomparable, -1 for less than other,
+    #   0 for equal to, 1 for greater than other
+    def <=>(other)
+      return unless other.is_a?(Type)
+      return super if other.instance_of?(Type)
+
+      if (result = prefix <=> other.prefix).nonzero?
+        result
+      else
+        super
+      end
+    end
+
+    # Checks whether this {KSUID::Prefixed} is equal to another
+    #
+    # @api semipublic
+    #
+    # @example Checks whether two KSUIDs are equal
+    #   KSUID.prefixed('evt_') == KSUID.prefixed('evt_')
+    #
+    # @param other [KSUID::Prefixed] the other {KSUID::Prefixed} to check against
+    # @return [Boolean]
+    def ==(other)
+      other.is_a?(Prefixed) &&
+        prefix == other.prefix &&
+        super
+    end
+
+    # Generates the key to use when using a {KSUID::Prefixed} as a hash key
+    #
+    # @api semipublic
+    #
+    # @example Using a KSUID as a Hash key
+    #   ksuid1 = KSUID.prefixed('evt_')
+    #   ksuid2 = ksuid1.dup
+    #   values_by_ksuid = {}
+    #
+    #   values_by_ksuid[ksuid1] = "example"
+    #   values_by_ksuid[ksuid2] #=> "example"
+    #
+    # @return [Integer]
+    def hash
+      [prefix, @uid].hash
+    end
+
+    # The {KSUID::Prefixed} as a prefixed, hex-encoded string
+    #
+    # This is generally useful for comparing against the Go tool.
+    #
+    # @api public
+    #
+    # @example
+    #   ksuid = KSUID::Prefixed.from_base62('0vdbMgWkU6slGpLVCqEFwkkZvuW', prefix: 'evt_')
+    #
+    #   ksuid.raw #=> "evt_0683F789049CC215C099D42B784DBE99341BD79C"
+    #
+    # @return [String] a prefixed, hex-encoded string
+    def raw
+      super.prepend(prefix)
+    end
+
+    # Converts the {KSUID::Prefixed} into a {KSUID::Type} by dropping the prefix
+    #
+    # @api public
+    #
+    # @example Convert an Event KSUID into a plain KSUID
+    #   ksuid = KSUID.prefixed('evt_')
+    #
+    #   ksuid.to_ksuid
+    #
+    # @return [KSUID::Type] the non-prefixed KSUID
+    def to_ksuid
+      KSUID.from_base62(to_s.sub(/\A#{prefix}/, ''))
+    end
+
+    # The {KSUID::Prefixed} as a base 62-encoded string
+    #
+    # @api public
+    #
+    # @example
+    #   ksuid = KSUID::Prefixed.from_base62('0vdbMgWkU6slGpLVCqEFwkkZvuW', prefix: 'evt_')
+    #
+    #   ksuid.to_s #=> "evt_0vdbMgWkU6slGpLVCqEFwkkZvuW"
+    #
+    # @return [String] the prefixed, base 62-encoded string for the {KSUID::Prefixed}
+    def to_s
+      super.prepend(prefix)
+    end
+  end
+end

--- a/lib/ksuid/type.rb
+++ b/lib/ksuid/type.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'base62'
-require_relative 'utils'
-
 module KSUID
   # Encapsulates the data type for a KSUID
   #

--- a/spec/ksuid/prefixed_spec.rb
+++ b/spec/ksuid/prefixed_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+RSpec.describe KSUID::Prefixed do
+  describe 'value object semantics' do
+    it 'uses value comparison instead of identity comparison' do
+      ksuid1 = KSUID.prefixed('evt_')
+      ksuid2 = ksuid1.dup
+      hash = {}
+
+      hash[ksuid1] = 'Hello, world'
+
+      aggregate_failures do
+        expect(ksuid1).to eq ksuid2
+        expect(ksuid1).to eql ksuid2
+        expect(ksuid1).not_to equal ksuid2
+        expect(hash[ksuid2]).to eq 'Hello, world'
+      end
+    end
+  end
+
+  describe '.call' do
+    it 'returns same-prefixed KSUIDs in tact' do
+      ksuid = KSUID.new
+
+      result = KSUID.call(ksuid)
+
+      expect(result).to eq(ksuid)
+    end
+
+    it 'prefixes KSUIDs' do
+      ksuid = KSUID.new
+
+      result = KSUID::Prefixed.call(ksuid, prefix: 'evt_')
+
+      expect(result.to_s).to eq("evt_#{ksuid}")
+    end
+
+    it 'raises for byte strings' do
+      ksuid = KSUID.prefixed('evt_')
+
+      expect { KSUID::Prefixed.call(ksuid.to_bytes, prefix: 'evt_') }
+        .to raise_error(ArgumentError)
+    end
+
+    it 'raises for byte arrays' do
+      ksuid = KSUID.prefixed('evt_')
+
+      expect { KSUID::Prefixed.call(ksuid.__send__(:uid), prefix: 'evt_') }
+        .to raise_error(ArgumentError)
+    end
+
+    it 'converts base 62 strings to KSUIDs' do
+      ksuid = KSUID.new
+
+      result = KSUID::Prefixed.call(ksuid.to_s, prefix: 'cus_')
+
+      expect(result.to_s).to eq("cus_#{ksuid}")
+    end
+
+    it 'returns nil if passed nil' do
+      result = KSUID::Prefixed.call(nil, prefix: 'evt_')
+
+      expect(result).to be_nil
+    end
+
+    it 'raise an ArgumentError upon an unknown value' do
+      expect { KSUID::Prefixed.call(1, prefix: 'evt_') }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#<=>' do
+    it 'does not sort with non-KSUIDs' do
+      ksuid = KSUID.prefixed('evt_')
+
+      expect(ksuid <=> ksuid.to_s).to be_nil
+    end
+
+    it 'sorts with un-prefixed KSUIDs by time' do
+      ksuid1 = KSUID.prefixed('evt_', time: Time.parse('2022-08-16 11:00:00 UTC'))
+      ksuid2 = KSUID.new(time: Time.parse('2022-08-16 10:00:00 UTC'))
+      ksuid3 = KSUID.new(time: Time.parse('2022-08-16 12:00:00 UTC'))
+
+      sorted = [ksuid1, ksuid2, ksuid3].sort
+
+      expect(sorted).to eq([ksuid2, ksuid1, ksuid3])
+    end
+
+    it 'sorts with prefixed KSUIDs by prefix, then time' do
+      ksuid1 = KSUID.prefixed('evt_', time: Time.parse('2022-08-16 11:00:00 UTC'))
+      ksuid2 = KSUID.prefixed('evt_', time: Time.parse('2022-08-16 10:00:00 UTC'))
+      ksuid3 = KSUID.prefixed('cus_', time: Time.parse('2022-08-16 12:00:00 UTC'))
+
+      sorted = [ksuid1, ksuid2, ksuid3].sort
+
+      expect(sorted).to eq([ksuid3, ksuid2, ksuid1])
+    end
+  end
+
+  describe '#==' do
+    it 'requires a prefixed KSUID' do
+      ksuid1 = KSUID.prefixed('evt_', time: Time.parse('2022-08-16 11:00:00 UTC'))
+      ksuid2 = KSUID.call(ksuid1)
+
+      expect(ksuid1).not_to eq(ksuid2)
+    end
+
+    it 'checks the prefix as well as the uid' do
+      ksuid1 = KSUID.prefixed('evt_', time: Time.parse('2022-08-16 11:00:00 UTC'))
+      ksuid2 = KSUID::Prefixed.call(ksuid1, prefix: 'evt_')
+      ksuid3 = KSUID::Prefixed.call(ksuid1, prefix: 'cus_')
+
+      expect(ksuid1).to eq(ksuid2)
+      expect(ksuid1).not_to eq(ksuid3)
+    end
+  end
+
+  describe '#raw' do
+    it 'prefixes the original KSUID payload' do
+      ksuid = KSUID::Prefixed.from_base62('evt_0vdbMgWkU6slGpLVCqEFwkkZvuW', prefix: 'evt_')
+
+      expect(ksuid.raw).to eq('evt_0683F789049CC215C099D42B784DBE99341BD79C')
+    end
+  end
+end


### PR DESCRIPTION
In some contexts, it can be helpful to prefix your KSUIDs with a tag to identify what model it belongs to. For example, you might identify Event KSUIDs with an `evt_` prefix and Customer KSUIDs with a `cus_` prefix.

To do so, you can now use the `KSUID.prefixed` method. You can also use a prefixed KSUID within ActiveRecord. These interoperate with normal KSUIDs in that they can convert to each other and order themselves appropriately by time.

Closes #9