### PR TITLE
Allow disabling the automatic generation of KSUIDs

### DIFF
--- a/activerecord-ksuid/CHANGELOG.md
+++ b/activerecord-ksuid/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 
 - Extracted the ActiveRecord behavior from [`ksuid-v0.5.0`](https://github.com/michaelherold/ksuid-ruby/tree/v0.5.0) into its own gem to slim down the gem and remove unnecessary functionality for people who only want the KSUID functionality.
+- Added the ability to disable the automatic generation of KSUIDs for fields by passing `auto_gen: false` to the module builder. This is helpful for foreign key fields, where an invalid value can raise errors, or for cases where you don't want to set the value until a later time.
 
 ### Fixed
 

--- a/activerecord-ksuid/README.md
+++ b/activerecord-ksuid/README.md
@@ -136,6 +136,28 @@ class Event < ApplicationRecord
 end
 ```
 
+##### Without generating a default value
+
+In some cases, such as foreign keys, you do not want to generate a default value for the field and, instead, want to set the value manually. When this is true, you can disable the default generation behavior by passing `auto_gen: false` to the module builder.
+
+```ruby
+class Event < ApplicationRecord
+  include ActiveRecord::KSUID[:correlation_id, auto_gen: false]
+
+  belongs_to :correlation, class_name: Event
+end
+```
+
+You can also use the [Attributes API](http://api.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html) directly:
+
+```ruby
+class Event < ApplicationRecord
+  attribute :correlation_id, :ksuid
+
+  belongs_to :correlation, class_name: Event
+end
+```
+
 #### Outside of Rails
 
 Outside of Rails, you cannot rely on the Railtie to load the appropriate files for you automatically. Toward the start of your application's boot process, you will want to require the following:

--- a/activerecord-ksuid/spec/active_record/ksuid/railtie_spec.rb
+++ b/activerecord-ksuid/spec/active_record/ksuid/railtie_spec.rb
@@ -74,8 +74,8 @@ end
 
 # A demonstration of a relation to a string KSUID primary key
 class EventCorrelation < ActiveRecord::Base
-  include ActiveRecord::KSUID[:from_id]
-  include ActiveRecord::KSUID[:to_id]
+  include ActiveRecord::KSUID[:from_id, auto_gen: false]
+  include ActiveRecord::KSUID[:to_id, auto_gen: false]
 
   belongs_to :from, class_name: 'EventPrimaryKey'
   belongs_to :to, class_name: 'EventPrimaryKey'
@@ -83,8 +83,8 @@ end
 
 # A demonstration of a relation to a binary KSUID primary key
 class EventBinaryCorrelation < ActiveRecord::Base
-  include ActiveRecord::KSUID[:from_id, binary: true]
-  include ActiveRecord::KSUID[:to_id, binary: true]
+  include ActiveRecord::KSUID[:from_id, auto_gen: false, binary: true]
+  include ActiveRecord::KSUID[:to_id, auto_gen: false, binary: true]
 
   belongs_to :from, class_name: 'EventBinary'
   belongs_to :to, class_name: 'EventBinary'
@@ -210,6 +210,13 @@ RSpec.describe 'ActiveRecord integration', type: :integration do
           .includes(:from, :to)
           .map { |correlation| "#{correlation.from.id} #{correlation.to.id}" }
       end.to issue_sql_queries(3)
+    end
+
+    it 'does not initialize fields marked with auto_gen: false', :aggregate_failures do
+      event = EventCorrelation.new
+
+      expect(event.from_id).to be_nil
+      expect(event.to_id).to be_nil
     end
   end
 


### PR DESCRIPTION
For certain cases, such as foreign keys, automatically generating a value for the field is incorrect. In these cases, use can now pass `auto_gen: false` to disable the automatic generation.

The number of options on the module builder are starting to seem like a smell. Perhaps it's time to unwind it in favor of the plain attribute API. We will retain it for backwards-compatibility though.

Closes #38