### PR TITLE
Fix binary KSUIDs on PostgreSQL

### DIFF
--- a/activerecord-ksuid/CHANGELOG.md
+++ b/activerecord-ksuid/CHANGELOG.md
@@ -9,3 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 
 - Extracted the ActiveRecord behavior from [`ksuid-v0.5.0`](https://github.com/michaelherold/ksuid-ruby/tree/v0.5.0) into its own gem to slim down the gem and remove unnecessary functionality for people who only want the KSUID functionality.
+
+### Fixed
+
+- Binary KSUIDs on PostgreSQL now correctly deserialize without any extra configuration.

--- a/activerecord-ksuid/lib/active_record/ksuid/binary_type.rb
+++ b/activerecord-ksuid/lib/active_record/ksuid/binary_type.rb
@@ -39,6 +39,7 @@ module ActiveRecord
         return unless value
 
         value = value.to_s if value.is_a?(::ActiveRecord::Type::Binary::Data)
+        value = ::KSUID::Utils.byte_string_from_hex(value[2..]) if value.start_with?('\x')
         ::KSUID.call(value)
       end
 


### PR DESCRIPTION
PostgreSQL serializes binary data differently than SQLite, such that we need to do an extra level of munging when deserializing data from the database. I'm not sure if this is due to something within the `pg` gem, `libpsql`, or Ruby, but filtering out an extra hexidecimal indicator on the front end of the string fixes the issue and causes no extra issues with MySQL or SQLite.