### PR TITLE
Track the Gemfile.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,8 @@
 **/_yardoc/
 **/coverage/
 **/doc/
-/activerecord-ksuid/gemfiles/*.gemfile.lock
 **/pkg/
 **/spec/examples.txt
 **/spec/reports/
 **/tmp/
 *.jsonld
-**/Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,163 @@
+PATH
+  remote: ksuid
+  specs:
+    ksuid (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+    ast (2.4.2)
+    benchmark-ips (2.10.0)
+    coderay (1.1.3)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
+    ffi (1.15.5)
+    ffi (1.15.5-java)
+    formatador (1.1.0)
+    guard (2.18.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, < 4.0)
+      lumberjack (>= 1.0.12, < 2.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.13.0)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-bundler (3.0.0)
+      bundler (>= 2.1, < 3)
+      guard (~> 2.2)
+      guard-compat (~> 1.1)
+    guard-compat (1.2.1)
+    guard-inch (0.2.0)
+      guard (~> 2)
+      inch (~> 0)
+    guard-rspec (4.7.3)
+      guard (~> 2.1)
+      guard-compat (~> 1.1)
+      rspec (>= 2.99.0, < 4.0)
+    guard-rubocop (1.5.0)
+      guard (~> 2.0)
+      rubocop (< 2.0)
+    guard-yard (2.2.1)
+      guard (>= 1.1.0)
+      yard (>= 0.7.0)
+    inch (0.8.0)
+      pry
+      sparkr (>= 0.2.0)
+      term-ansicolor
+      yard (~> 0.9.12)
+    json (2.6.2)
+    json (2.6.2-java)
+    listen (3.7.1)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    lumberjack (1.2.8)
+    method_source (1.0.0)
+    minitest (5.16.3)
+    nenv (0.3.0)
+    notiffany (0.1.3)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    parallel (1.22.1)
+    parser (3.1.2.1)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry (0.14.1-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
+    rainbow (3.1.1)
+    rake (13.0.6)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
+    regexp_parser (2.6.0)
+    rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.1)
+    rubocop (1.35.0)
+      json (~> 2.3)
+      parallel (~> 1.10)
+      parser (>= 3.1.2.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.21.0)
+      parser (>= 3.1.1.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
+    rubocop-rspec (2.13.2)
+      rubocop (~> 1.33)
+    ruby-progressbar (1.11.0)
+    shellany (0.0.1)
+    simplecov (0.17.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
+    sparkr (0.4.1)
+    spoon (0.0.6)
+      ffi
+    sync (0.5.0)
+    term-ansicolor (1.7.1)
+      tins (~> 1.0)
+    thor (1.2.1)
+    tins (1.31.1)
+      sync
+    unicode-display_width (2.3.0)
+    webrick (1.7.0)
+    yard (0.9.28)
+      webrick (~> 1.7.0)
+    yard-doctest (0.1.17)
+      minitest
+      yard
+    yardstick (0.9.9)
+      yard (~> 0.8, >= 0.8.7.2)
+
+PLATFORMS
+  ruby
+  universal-java-11
+
+DEPENDENCIES
+  appraisal
+  benchmark-ips
+  guard-bundler
+  guard-inch
+  guard-rspec
+  guard-rubocop
+  guard-yard
+  inch
+  ksuid!
+  pry
+  rake
+  rspec (~> 3.6)
+  rubocop (= 1.35.0)
+  rubocop-rake
+  rubocop-rspec
+  simplecov (< 0.18)
+  yard (~> 0.9)
+  yard-doctest
+  yardstick
+
+BUNDLED WITH
+   2.3.23


### PR DESCRIPTION
In order to make contributing easier, we will now start tracking the Gemfile.lock file in the repository so new contributors do not have to do the dance to get dependencies to all lined up in the event that there is a conflict down the road.