### PR TITLE
Update to action versions on supported Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
           - jruby-9.3
     name: Test ksuid on Ruby ${{ matrix.ruby }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ksuid/vendor/bundle
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile.lock') }}
@@ -84,11 +84,11 @@ jobs:
             rails: "7.0"
     name: Test activerecord-ksuid on Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}, and MySQL
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: activerecord-ksuid/vendor/bundle
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-${{ hashFiles('Gemfile.lock', 'activerecord-ksuid/gemfiles/*.gemfile.lock') }}
@@ -148,11 +148,11 @@ jobs:
             rails: "7.0"
     name: Test activerecord-ksuid on Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}, and PostgreSQL
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: activerecord-ksuid/vendor/bundle
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-${{ hashFiles('Gemfile.lock', 'activerecord-ksuid/gemfiles/*.gemfile.lock') }}
@@ -198,11 +198,11 @@ jobs:
             rails: "7.0"
     name: Test activerecord-ksuid on Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}, and SQLite
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: activerecord-ksuid/vendor/bundle
           key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ matrix.rails }}-${{ hashFiles('Gemfile.lock', 'activerecord-ksuid/gemfiles/*.gemfile.lock') }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Inch
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-linting-${{ hashFiles('Gemfile.lock') }}
@@ -34,11 +34,11 @@ jobs:
     runs-on: ubuntu-latest
     name: Rubocop
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-linting-${{ hashFiles('Gemfile.lock') }}


### PR DESCRIPTION
Node 12 has been unsupported for quite a while and GitHub is [pushing to update all actions to use Node 16][1]. This change updates actions to versions that run on the supported version of Node.

[1]: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/